### PR TITLE
Get rid of optional properties

### DIFF
--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -84,6 +84,9 @@ export interface BeatmapExtendedWithFailtimesBeatmapsetextended extends BeatmapE
 	beatmapset: BeatmapsetExtended
 }
 
+/**
+ * Expected from BeatmapWithBeatmapset, Score
+ */
 export interface Beatmapset {
 	artist: string
 	artist_unicode: string
@@ -109,7 +112,7 @@ export interface Beatmapset {
 	source: string
 	spotlight: boolean
 	/**
-	 * Is it ranked, is it graveyard, etc
+	 * Is it ranked, is it graveyarded, etc
 	 */
 	status: string
 	/**

--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -11,6 +11,9 @@ export enum RankStatus {
 	Loved 		= 4
 }
 
+/**
+ * @privateRemarks While not expected from anywhere, it should be exported for ease of use purposes
+ */
 export interface Beatmap {
 	beatmapset_id: number
 	difficulty_rating: number
@@ -20,20 +23,33 @@ export interface Beatmap {
 	total_length: number
 	user_id: number
 	version: string
-	/**
-	 * Beatmapset for Beatmap object, BeatmapsetExtended for BeatmapExtended object, null if the beatmap doesn't have associated beatmapset (e.g. deleted)
-	 */
-	beatmapset?: BeatmapsetExtended | Beatmapset | null
-	checksum?: string
-	failtimes?: Failtimes
-	max_combo?: number
 }
 
-export interface BeatmapExtended extends Beatmap {
+/**
+ * Expected from Match
+ */
+export interface BeatmapWithBeatmapset extends Beatmap {
+	beatmapset: Beatmapset
+}
+
+interface BeatmapWithChecksum extends Beatmap {
+	checksum: string
+}
+
+/**
+ * Expected from PlaylistItem
+ */
+export interface BeatmapWithBeatmapsetChecksumMaxcombo extends BeatmapWithBeatmapset, BeatmapWithChecksum {
+	max_combo: number
+}
+
+/**
+ * Expected from Score
+ */
+export interface BeatmapExtended extends BeatmapWithChecksum {
 	accuracy: number
 	ar: number
-	beatmapset_id: number
-	bpm: number | null
+	bpm: number
 	convert: boolean
 	count_circles: number
 	count_sliders: number
@@ -49,6 +65,23 @@ export interface BeatmapExtended extends Beatmap {
 	playcount: number
 	ranked: RankStatus
 	url: string
+}
+
+/**
+ * Expected from BeatmapsetExtendedPlus
+ */
+export interface BeatmapExtendedWithFailtimes extends BeatmapExtended {
+	failtimes: {
+		exit: number[]
+		fail: number[]
+	}
+}
+
+/**
+ * Expected from api.getBeatmap()
+ */
+export interface BeatmapExtendedWithFailtimesBeatmapsetextended extends BeatmapExtendedWithFailtimes {
+	beatmapset: BeatmapsetExtended
 }
 
 export interface Beatmapset {
@@ -69,46 +102,36 @@ export interface Beatmapset {
 	id: number
 	nsfw: boolean
 	play_count: number
+	/**
+	 * A string like that, where id is the `id` of the beatmapset: `//b.ppy.sh/preview/58951.mp3`
+	 */
 	preview_url: string
 	source: string
+	spotlight: boolean
+	/**
+	 * Is it ranked, is it graveyard, etc
+	 */
 	status: string
+	/**
+	 * A title readable by any english-speaking person, so it'd be romaji if the song's title is in Japanese
+	 */
 	title: string
+	/**
+	 * Basically the title is the original language, so with hiraganas and kanji if Japanese
+	 */
 	title_unicode: string
 	user_id: number
 	video: boolean
-	beatmaps?: BeatmapExtended[]
-	converts?: BeatmapExtended[] | 0
-	current_nominations?: {
-		beatmapset_id: number
-		rulesets: Rulesets[] | null
-		reset: boolean
-		user_id: number
-	}[]
-	current_user_attributes?: any
-	description?: {
-		description: string
-	}
-	discussions?: any
-	events?: any
-	genre?: {
-		id: number
-		name: string
-	}
-	has_favourited?: boolean
-	language?: {
-		id: number
-		name: string
-	}
-	nominations?: any
-	pack_tags?: string[]
-	ratings?: number[]
-	recent_favourites?: User[]
-	related_users?: User[]
-	user?: User
 }
 
+/**
+ * Expected from RankingsSpotlight, BeatmapExtendedWithFailtimesBeatmapsetextended
+ */
 export interface BeatmapsetExtended extends Beatmapset {
 	availability: {
+		/**
+		 * So it's `false` if you can download it
+		 */
 		download_disabled: boolean
 		more_information: string | null
 	}
@@ -117,12 +140,14 @@ export interface BeatmapsetExtended extends Beatmapset {
 	creator: string
 	deleted_at: string | null
 	discussion_locked: boolean
-	"hype.current": number
-	"hype.required": number
+	hype: {
+		current: number
+		required: number
+	}
 	is_scoreable: boolean
 	last_updated: Date
-	legacy_thread_url: string | null
-	nominations: {
+	legacy_thread_url: string
+	nominations_summary: {
 		current: number
 		required: number
 	}
@@ -131,8 +156,50 @@ export interface BeatmapsetExtended extends Beatmapset {
 	source: string
 	storyboard: boolean
 	submitted_date: Date | null
-	tags: string
-	has_favourited?: any
+	/**
+	 * 0 if no tags at all, a string with tags separated from each other by a whitespace
+	 */
+	tags: string | 0
+}
+
+/**
+ * Expected from api.getBeatmapset()
+ */
+export interface BeatmapsetExtendedPlus extends BeatmapsetExtended {
+	/**
+	 * The different beatmaps/difficulties this beatmapset has
+	 */
+	beatmaps: BeatmapExtendedWithFailtimes[]
+	/**
+	 * The different beatmaps made for osu!, but converted to the other Rulesets
+	 */
+	converts: BeatmapExtendedWithFailtimes[]
+	current_nominations: {
+		beatmapset_id: number
+		rulesets: Rulesets[]
+		reset: boolean
+		user_id: number
+	}[]
+	description: {
+		/**
+		 * In HTML
+		 */
+		description: string
+	}
+	genre: {
+		id: number
+		name: string
+	}
+	has_favourited: boolean
+	language: {
+		id: number
+		name: string
+	}
+	pack_tags: string[]
+	ratings: number[]
+	recent_favourites: User[]
+	related_users: User[]
+	user: User
 }
 
 export interface BeatmapDifficultyAttributes {
@@ -206,9 +273,4 @@ export interface BeatmapPack {
 		 */
 		completed: boolean
 	}
-}
-
-export interface Failtimes {
-	exit?: number[]
-	fail?: number[]
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,7 +5,7 @@ import { Beatmap, BeatmapExtended, BeatmapDifficultyAttributes, BeatmapPack, Bea
 import { Leader, Match, MatchInfo, MultiplayerScore, PlaylistItem, Room } from "./multiplayer.js"
 import { Rulesets, Mod } from "./misc.js"
 import { BeatmapUserScore, Score } from "./score.js"
-import { Rankings, Spotlight } from "./ranking.js"
+import { Rankings, RankingsCountry, RankingsSpotlight, Spotlight } from "./ranking.js"
 import { ChangelogBuild, UpdateStream } from "./changelog.js"
 
 export {User, UserExtended, KudosuHistory}
@@ -555,18 +555,37 @@ export class API {
 	/**
 	 * Get the top players of the game, with some filters!
 	 * @param ruleset Self-explanatory, is also known as "Gamemode"
-	 * @param type `charts` is essentially for older spotlights, the rest should be obvious enough
+	 * @param type Rank players by their performance points or by their ranked score?
 	 * @param page (defaults to 1) Imagine `Rankings` as a page, it can only have a maximum of 50 players, while 50 others may be on the next one
 	 * @param filter What kind of players do you want to see? Defaults to `all`, `friends` has no effect if no authorized user
 	 * @param country Only get players from a specific country, using its ISO 3166-1 alpha-2 country code! (France would be `FR`, United States `US`)
-	 * @param spotlight If `type` is `charts`, you can specify the id of a spotlight! Defaults to the latest spotlight
 	 * @param variant If `type` is `performance` and `ruleset` is mania, choose between 4k and 7k!
-	 * @scope public (only if there's an authorized user) (the `friends.read` scope isn't needed to use the `friends` filter)
 	 */
-	async getRanking(ruleset: Rulesets, type: "charts" | "country" | "performance" | "score", page: number = 1, filter: "all" | "friends" = "all",
-	country?: string, spotlight?: {id: number} | Spotlight, variant?: "4k" | "7k"): Promise<Rankings> {
-		const response = await this.request("get", `rankings/${Rulesets[ruleset]}/${type}`, {page, filter, country, spotlight, variant})
+	async getRanking(ruleset: Rulesets, type: "performance" | "score", page: number = 1, filter: "all" | "friends" = "all",
+	country?: string, variant?: "4k" | "7k"): Promise<Rankings> {
+		const response = await this.request("get", `rankings/${Rulesets[ruleset]}/${type}`, {page, filter, country, variant})
 		return correctType(response) as Rankings
+	}
+
+	/**
+	 * Get the top countries of a specific ruleset!
+	 * @param ruleset On which Ruleset should the countries be compared?
+	 * @param page (defaults to 1) Imagine `Rankings` as a page, it can only have a maximum of 50 countries, while 50 others may be on the next one
+	 */
+	async getCountryRanking(ruleset: Rulesets, page: number = 1): Promise<RankingsCountry> {
+		const response = await this.request("get", `rankings/${Rulesets[ruleset]}/country`, {page})
+		return correctType(response) as RankingsCountry
+	}
+
+	/**
+	 * Get the rankings of a spotlight from 2009 to 2020 on a specific ruleset!
+	 * @param ruleset Each spotlight has a different ranking (and often maps) depending on the ruleset
+	 * @param spotlight The spotlight in question
+	 * @param filter What kind of players do you want to see? Defaults to `all`, `friends` has no effect if no authorized user
+	 */
+	async getSpotlightRanking(ruleset: Rulesets, spotlight: {id: number} | Spotlight, filter: "all" | "friends" = "all"): Promise<RankingsSpotlight> {
+		const response = await this.request("get", `rankings/${Rulesets[ruleset]}/charts`, {spotlight: spotlight.id, filter})
+		return correctType(response) as RankingsSpotlight
 	}
 
 	/**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,7 +4,7 @@ import { User, UserExtended, KudosuHistory, UserWithKudosu, UserWithCountryCover
 import { Beatmap, BeatmapExtended, BeatmapDifficultyAttributes, BeatmapPack, Beatmapset, BeatmapsetExtended, BeatmapExtendedWithFailtimesBeatmapsetextended, BeatmapsetExtendedPlus } from "./beatmap.js"
 import { Leader, Match, MatchInfo, MultiplayerScore, PlaylistItem, Room } from "./multiplayer.js"
 import { Rulesets, Mod } from "./misc.js"
-import { BeatmapUserScore, Score } from "./score.js"
+import { BeatmapUserScore, Score, ScoreWithUser, ScoreWithUserBeatmapBeatmapset } from "./score.js"
 import { Rankings, RankingsCountry, RankingsSpotlight, Spotlight } from "./ranking.js"
 import { ChangelogBuild, UpdateStream } from "./changelog.js"
 
@@ -325,10 +325,10 @@ export class API {
 	 * @param offset How many elements that would be at the top of the returned array get skipped (while still filling the array up to the limit)
 	 */
 	async getUserScores(user: {id: number} | User, type: "best" | "firsts" | "recent", limit?: number,
-	ruleset?: Rulesets, include_fails: boolean = false, offset?: number): Promise<Score[]> {
+	ruleset?: Rulesets, include_fails: boolean = false, offset?: number): Promise<ScoreWithUserBeatmapBeatmapset[]> {
 		const mode = ruleset ? Rulesets[ruleset] : undefined
 		const response = await this.request("get", `users/${user.id}/scores/${type}`, {limit, mode, offset, include_fails: String(Number(include_fails))})
-		return response.map((s: Score) => correctType(s)) as Score[]
+		return response.map((s: ScoreWithUserBeatmapBeatmapset) => correctType(s)) as ScoreWithUserBeatmapBeatmapset[]
 	}
 
 	/**
@@ -387,6 +387,19 @@ export class API {
 	ruleset?: Rulesets): Promise<BeatmapDifficultyAttributes> {
 		const response = await this.request("post", `beatmaps/${beatmap.id}/attributes`, {ruleset_id: ruleset, mods})
 		return correctType(response.attributes) as BeatmapDifficultyAttributes
+	}
+
+	/**
+	 * Get the top scores of a beatmap!
+	 * @param beatmap The Beatmap in question
+	 * @param ruleset The Ruleset used to make the scores, useful if they were made on a convert
+	 * @param mods (2023-11-16) Currently doesn't do anything
+	 * @param type (2023-11-16) Currently doesn't do anything
+	 */
+	async getBeatmapScores(beatmap: {id: number} | Beatmap, ruleset?: Rulesets, mods?: string[], type?: string): Promise<ScoreWithUser[]> {
+		const mode = ruleset ? Rulesets[ruleset] : undefined
+		const response = await this.request("get", `beatmaps/${beatmap.id}/scores`, {mode, mods, type})
+		return response.scores.map((s: ScoreWithUser) => correctType(s)) as ScoreWithUser[]
 	}
 
 	/**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@ import fetch, { FetchError } from "node-fetch"
 import querystring from "querystring"
 import { User, UserExtended, KudosuHistory, UserWithKudosu, UserWithCountryCoverGroupsStatisticsSupport, UserExtendedWithStatisticsrulesets, UserWithCountryCoverGroupsStatisticsrulesets } from "./user.js"
 import { Beatmap, BeatmapExtended, BeatmapDifficultyAttributes, BeatmapPack, Beatmapset, BeatmapsetExtended, BeatmapExtendedWithFailtimesBeatmapsetextended, BeatmapsetExtendedPlus } from "./beatmap.js"
-import { Leader, Match, MatchInfo, MultiplayerScore, PlaylistItem, Room } from "./multiplayer.js"
+import { Leader, Match, MatchInfo, MultiplayerScore, MultiplayerScores, PlaylistItem, Room } from "./multiplayer.js"
 import { Rulesets, Mod } from "./misc.js"
 import { BeatmapUserScore, Score, ScoreWithUser, ScoreWithUserBeatmapBeatmapset } from "./score.js"
 import { Rankings, RankingsCountry, RankingsSpotlight, Spotlight } from "./ranking.js"
@@ -528,13 +528,18 @@ export class API {
 	}
 
 	/**
-	 * Get the scores on a specific item of a room, for a maximum of 50!
+	 * Get the scores on a specific item of a room!
+	 * @param item An object with the id of the item in question, as well as the id of the room
+	 * @param limit How many scores maximum? Defaults to 50, the maximum the API will return
+	 * @param sort Sort by scores, ascending or descending? Defaults to descending
+	 * @param cursor_string Use a MultiplayerScores' `params` and `cursor_string` to get the next page (scores 51 to 100 for example)
 	 * @remarks (2023-11-10) Items are broken for multiplayer (real-time) rooms, not for playlists (like spotlights), that's an osu! bug
 	 * https://github.com/ppy/osu-web/issues/10725
 	 */
-	async getPlaylistItemScores(item: {id: number, room_id: number} | PlaylistItem): Promise<MultiplayerScore[]> {
-		const response = await this.request("get", `rooms/${item.room_id}/playlist/${item.id}/scores`)
-		return response.scores.map((s: MultiplayerScore) => correctType(s)) as MultiplayerScore[]
+	async getPlaylistItemScores(item: {id: number, room_id: number} | PlaylistItem, limit: number = 50,
+	sort: "score_asc" | "score_desc" = "score_desc", cursor_string?: string): Promise<MultiplayerScores> {
+		const response = await this.request("get", `rooms/${item.room_id}/playlist/${item.id}/scores`, {limit, sort, cursor_string})
+		return correctType(response) as MultiplayerScores
 	}
 
 	/**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import fetch, { FetchError } from "node-fetch"
 import querystring from "querystring"
 import { User, UserExtended, KudosuHistory, UserWithKudosu, UserWithCountryCoverGroupsStatisticsSupport, UserExtendedWithStatisticsrulesets, UserWithCountryCoverGroupsStatisticsrulesets } from "./user.js"
-import { Beatmap, BeatmapExtended, BeatmapDifficultyAttributes, BeatmapPack, Beatmapset, BeatmapsetExtended } from "./beatmap.js"
+import { Beatmap, BeatmapExtended, BeatmapDifficultyAttributes, BeatmapPack, Beatmapset, BeatmapsetExtended, BeatmapExtendedWithFailtimesBeatmapsetextended, BeatmapsetExtendedPlus } from "./beatmap.js"
 import { Leader, Match, MatchInfo, MultiplayerScore, PlaylistItem, Room } from "./multiplayer.js"
 import { Rulesets, Mod } from "./misc.js"
 import { BeatmapUserScore, Score } from "./score.js"
@@ -358,9 +358,9 @@ export class API {
 	 * Get extensive beatmap data about whichever beatmap you want!
 	 * @param beatmap An object with the id of the beatmap you're trying to get
 	 */
-	async getBeatmap(beatmap: {id: number} | Beatmap): Promise<BeatmapExtended> {
+	async getBeatmap(beatmap: {id: number} | Beatmap): Promise<BeatmapExtendedWithFailtimesBeatmapsetextended> {
 		const response = await this.request("get", `beatmaps/${beatmap.id}`)
-		return correctType(response) as BeatmapExtended
+		return correctType(response) as BeatmapExtendedWithFailtimesBeatmapsetextended
 	}
 
 	/**
@@ -420,9 +420,9 @@ export class API {
 	 * Get extensive beatmapset data about whichever beatmapset you want!
 	 * @param beatmapset An object with the id of the beatmapset you're trying to get
 	 */
-	async getBeatmapset(beatmapset: {id: number} | Beatmapset): Promise<BeatmapsetExtended> {
+	async getBeatmapset(beatmapset: {id: number} | Beatmapset): Promise<BeatmapsetExtendedPlus> {
 		const response = await this.request("get", `beatmapsets/${beatmapset.id}`)
-		return correctType(response) as BeatmapsetExtended
+		return correctType(response) as BeatmapsetExtendedPlus
 	}
 
 	/**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 import fetch, { FetchError } from "node-fetch"
 import querystring from "querystring"
-import { User, UserExtended, KudosuHistory } from "./user.js"
+import { User, UserExtended, KudosuHistory, UserWithKudosu, UserWithCountryCoverGroupsStatisticsSupport, UserExtendedWithStatisticsrulesets, UserWithCountryCoverGroupsStatisticsrulesets } from "./user.js"
 import { Beatmap, BeatmapExtended, BeatmapDifficultyAttributes, BeatmapPack, Beatmapset, BeatmapsetExtended } from "./beatmap.js"
 import { Leader, Match, MatchInfo, MultiplayerScore, PlaylistItem, Room } from "./multiplayer.js"
 import { Rulesets, Mod } from "./misc.js"
@@ -287,9 +287,9 @@ export class API {
 	 * @param ruleset Defaults to the user's default/favourite Ruleset
 	 * @scope identify
 	 */
-	async getResourceOwner(ruleset?: Rulesets): Promise<UserExtended> {
+	async getResourceOwner(ruleset?: Rulesets): Promise<UserExtendedWithStatisticsrulesets> {
 		const response = await this.request("get", "me", {mode: ruleset})
-		return correctType(response) as UserExtended
+		return correctType(response) as UserExtendedWithStatisticsrulesets
 	}
 	
 	/**
@@ -310,9 +310,9 @@ export class API {
 	 * Get user data for up to 50 users at once!
 	 * @param ids An array composed of the ids of the users you want
 	 */
-	async getUsers(ids: number[]): Promise<User[]> {
+	async getUsers(ids: number[]): Promise<UserWithCountryCoverGroupsStatisticsrulesets[]> {
 		const response = await this.request("get", "users", {ids})
-		return response.users.map((u: User) => correctType(u)) as User[]
+		return response.users.map((u: UserWithCountryCoverGroupsStatisticsrulesets) => correctType(u)) as UserWithCountryCoverGroupsStatisticsrulesets[]
 	}
 
 	/**
@@ -346,9 +346,9 @@ export class API {
 	 * Get user data of each friend of the authorized user
 	 * @scope friends.read
 	 */
-	async getFriends(): Promise<User[]> {
+	async getFriends(): Promise<UserWithCountryCoverGroupsStatisticsSupport[]> {
 		const response = await this.request("get", "friends")
-		return response.map((f: User) => correctType(f)) as User[]
+		return response.map((f: UserWithCountryCoverGroupsStatisticsSupport) => correctType(f)) as UserWithCountryCoverGroupsStatisticsSupport[]
 	}
 
 	
@@ -547,9 +547,9 @@ export class API {
 	/**
 	 * Get the top 50 players who have the most total kudosu!
 	 */
-	async getKudosuRanking(): Promise<User[]> {
+	async getKudosuRanking(): Promise<UserWithKudosu[]> {
 		const response = await this.request("get", "rankings/kudosu")
-		return response.ranking.map((u: User) => correctType(u)) as User[]
+		return response.ranking.map((u: UserWithKudosu) => correctType(u)) as UserWithKudosu[]
 	}
 
 	/**

--- a/lib/multiplayer.ts
+++ b/lib/multiplayer.ts
@@ -1,6 +1,6 @@
 import { Beatmap } from "./beatmap.js"
 import { Rulesets, Mod } from "./misc.js"
-import { UserExtended, User } from "./user.js"
+import { User, UserWithCountry, UserWithCountryCover } from "./user.js"
 
 /**
  * @remarks This is entirely absent from the official documentation
@@ -47,12 +47,18 @@ export interface PlaylistItem {
 
 export interface MultiplayerScore {
 	id: number
+	/**
+	 * The ID of the user who made the score
+	 */
 	user_id: number
 	room_id: number
 	playlist_item_id: number
 	beatmap_id: number
 	rank: string
 	total_score: number
+	/**
+	 * In a format where `96.40%` would be `0.9640` (and no number afterwards)
+	 */
 	accuracy: number
 	max_combo: number
 	mods: Mod[]
@@ -61,11 +67,14 @@ export interface MultiplayerScore {
 	started_at?: Date
 	ended_at?: Date
 	position?: number | null
-	scores_around: {
+	/**
+	 * (2023-11-14) Doesn't seem to be there anymore for getPlaylistItemScores?
+	 */
+	scores_around?: {
 		higher: MultiplayerScores
 		lower: MultiplayerScores
 	}
-	user: UserExtended
+	user: UserWithCountryCover
 }
 
 export interface MultiplayerScores {
@@ -77,6 +86,9 @@ export interface MultiplayerScores {
 }
 
 export interface Leader {
+	/**
+	 * In a format where `96.40%` would be `0.9640` (likely with some numbers after the zero)
+	 */
 	accuracy: number
 	attempts: number
 	completed: number
@@ -84,7 +96,7 @@ export interface Leader {
 	room_id: number
 	total_score: number
 	user_id: number
-	user: User
+	user: UserWithCountry
 }
 
 export interface MatchInfo {
@@ -149,7 +161,7 @@ export interface Match {
 			}
 		}[]
 	}
-	users: User[]
+	users: UserWithCountry[]
 	first_event_id: number
 	latest_event_id: number
 	current_game_id: number | null

--- a/lib/multiplayer.ts
+++ b/lib/multiplayer.ts
@@ -1,35 +1,55 @@
 import { BeatmapWithBeatmapset, BeatmapWithBeatmapsetChecksumMaxcombo } from "./beatmap.js"
 import { Rulesets, Mod } from "./misc.js"
+import { ScoreWithMatch } from "./score.js"
 import { User, UserWithCountry, UserWithCountryCover } from "./user.js"
 
 /**
- * @remarks This is entirely absent from the official documentation
- * even though it's essential to get scores, due to the playlist system
+ * Expected from api.getRoom()
  */
 export interface Room {
-	id: number
-	name: string
+	active: boolean
+	auto_skip: boolean
 	category: string
+	channel_id: number
+	ends_at: Date | null
+	has_password: boolean
+	host: UserWithCountry
+	id: number
+	max_attempts: number | null
+	name: string
+	participant_count: number
+	playlist: PlaylistItem[]
+	queue_mode: string
+	recent_participants: User[]
+	starts_at: Date
 	type: string
 	user_id: number
-	starts_at: Date
-	ends_at: Date | null
-	max_attempts: number | null
-	participant_count: number
-	channel_id: number
-	active: boolean
-	has_password: boolean
-	queue_mode: string
-	auto_skip: boolean
-	current_user_score: {[k: string]: any}
-	host: User
-	playlist: PlaylistItem[]
-	recent_participants: User[]
+	/**
+	 * Only exists if authorized user
+	 */
+	current_user_score?: {
+		/**
+		 * In a format where `96.40%` would be `0.9640` (likely with some numbers after the zero)
+		 */
+		accuracy: number
+		attempts: number
+		completed: number
+		pp: number
+		room_id: number
+		total_score: number
+		user_id: number
+		/**
+		 * How many (completed?) attempts on each item? Empty array if the multiplayer room is the realtime kind
+		 */
+		playlist_item_attempts: {
+			attempts: number
+			id: number
+		}[]
+	}
 }
 
 /**
- * @remarks This is entirely absent from the official documentation
- * even though it's essential to get scores, due to the playlist system
+ * Expected from Room
  */
 export interface PlaylistItem {
 	id: number
@@ -45,44 +65,72 @@ export interface PlaylistItem {
 	beatmap: BeatmapWithBeatmapsetChecksumMaxcombo
 }
 
+/**
+ * Expected from MultiplayerScores
+ * @remarks This particular interface seems really unstable, beware
+ */
 export interface MultiplayerScore {
-	id: number
-	/**
-	 * The ID of the user who made the score
-	 */
-	user_id: number
-	room_id: number
-	playlist_item_id: number
-	beatmap_id: number
-	rank: string
-	total_score: number
 	/**
 	 * In a format where `96.40%` would be `0.9640` (and no number afterwards)
 	 */
 	accuracy: number
+	beatmap_id: number
+	ended_at: Date
 	max_combo: number
-	mods: Mod[]
-	statistics: any
-	passed: boolean
-	started_at?: Date
-	ended_at?: Date
-	position?: number | null
-	/**
-	 * (2023-11-14) Doesn't seem to be there anymore for getPlaylistItemScores?
-	 */
-	scores_around?: {
-		higher: MultiplayerScores
-		lower: MultiplayerScores
+	max_statistics: {
+		great: number
+		ignore_hit: number
+		large_tick_hit: number
+		small_tick_hit: number
 	}
+	mods: Mod[]
+	passed: boolean
+	rank: string
+	ruleset_id: number
+	started_at: Date
+	statistics: {
+		great: number
+		large_bonus: number
+		large_tick_hit: number
+		meh: number
+		miss: number
+		ok: number
+		small_bonus: number
+		small_tick_hit: number
+		small_tick_miss: number
+	}
+	total_score: number
+	user_id: number
+	playlist_item_id: number
+	room_id: number
+	id: number
+	pp: number | null
+	replay: boolean
+	type: string
 	user: UserWithCountryCover
 }
 
+/**
+ * Expected from api.getPlaylistItemScores()
+ */
 export interface MultiplayerScores {
-	cursor_string: any
-	params: {[k: string]: any}
+	params: {
+		limit: number
+		sort: string
+	}
+	/**
+	 * How many scores there are across all pages, not necessarily `scores.length`
+	 */
+	total: number
 	scores: MultiplayerScore[]
-	total: number | null
+	/**
+	 * Will be null if not an authorized user or if the authorized user has no score
+	 */
 	user_score: MultiplayerScore | null
+	/**
+	 * Will be null if there is no next page
+	 */
+	cursor_string: string | null
 }
 
 export interface Leader {
@@ -99,6 +147,9 @@ export interface Leader {
 	user: UserWithCountry
 }
 
+/**
+ * Expected from api.getMatches(), Match
+ */
 export interface MatchInfo {
 	id: number
 	start_time: Date
@@ -106,16 +157,25 @@ export interface MatchInfo {
 	name: string
 }
 
+/**
+ * Expected from api.getMatch()
+ */
 export interface Match {
 	match: MatchInfo
 	events: {
 		id: number
 		detail: {
 			type: string
+			/**
+			 * If `detail.type` is `other`, this exists and will be the name of the room
+			 */
 			text?: string
 		}
 		timestamp: Date
 		user_id: number | null
+		/**
+		 * If `detail.type` is `other`, then this should exist!
+		 */
 		game?: {
 			beatmap_id: number
 			id: number
@@ -127,39 +187,8 @@ export interface Match {
 			team_type: string
 			mods: string[]
 			beatmap: BeatmapWithBeatmapset
+			scores: ScoreWithMatch[]
 		}
-		scores?: {
-			accuracy: number
-			best_id: number | null
-			created_at: Date
-			id: number | null
-			max_combo: number
-			mode: string
-			mode_int: Rulesets
-			mods: string[]
-			passed: boolean,
-			perfect: number
-			pp: number | null
-			rank: string
-			replay: boolean
-			score: number
-			statistics: {
-				count_100: number
-				count_300: number
-				count_50: number
-				count_geki: number
-				count_katu: number
-				count_miss: number
-			}
-			type: string
-			user_id: number
-			current_user_attributes: {[k: string]: any}
-			match: {
-				slot: number
-				team: string
-				pass: boolean
-			}
-		}[]
 	}[]
 	users: UserWithCountry[]
 	first_event_id: number

--- a/lib/multiplayer.ts
+++ b/lib/multiplayer.ts
@@ -1,4 +1,4 @@
-import { Beatmap } from "./beatmap.js"
+import { BeatmapWithBeatmapset, BeatmapWithBeatmapsetChecksumMaxcombo } from "./beatmap.js"
 import { Rulesets, Mod } from "./misc.js"
 import { User, UserWithCountry, UserWithCountryCover } from "./user.js"
 
@@ -42,7 +42,7 @@ export interface PlaylistItem {
 	owner_id: number
 	playlist_order: number
 	played_at: Date
-	beatmap: Beatmap
+	beatmap: BeatmapWithBeatmapsetChecksumMaxcombo
 }
 
 export interface MultiplayerScore {
@@ -126,7 +126,7 @@ export interface Match {
 			scoring_type: string
 			team_type: string
 			mods: string[]
-			beatmap: Beatmap
+			beatmap: BeatmapWithBeatmapset
 		}
 		scores?: {
 			accuracy: number
@@ -160,7 +160,7 @@ export interface Match {
 				pass: boolean
 			}
 		}[]
-	}
+	}[]
 	users: UserWithCountry[]
 	first_event_id: number
 	latest_event_id: number

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -1,5 +1,5 @@
 import { BeatmapsetExtended } from "./beatmap.js"
-import { UserStatistics } from "./user.js"
+import { UserStatisticsWithUser } from "./user.js"
 
 export interface Spotlight {
 	id: number
@@ -12,7 +12,7 @@ export interface Spotlight {
 }
 
 export interface Rankings {
-	ranking: UserStatistics[]
+	ranking: UserStatisticsWithUser[]
 	/**
 	 * Total amount of users available across all pages, not on this specific page! Maximum of 10000
 	 */

--- a/lib/ranking.ts
+++ b/lib/ranking.ts
@@ -1,28 +1,78 @@
 import { BeatmapsetExtended } from "./beatmap.js"
 import { UserStatisticsWithUser } from "./user.js"
 
+/**
+ * Expected from api.getSpotlights()
+ */
 export interface Spotlight {
 	id: number
 	name: string
 	start_date: Date
 	end_date: Date
 	type: string
+	/**
+	 * Pretty sure this is only `true` when the spotlight has different beatmaps for each ruleset
+	 */
 	mode_specific: boolean
-	participant_count?: number
 }
 
-export interface Rankings {
-	ranking: UserStatisticsWithUser[]
-	/**
-	 * Total amount of users available across all pages, not on this specific page! Maximum of 10000
-	 */
-	total: number
+/**
+ * Expected from RankingsSpotlight
+ */
+export interface SpotlightWithParticipantcount extends Spotlight {
+	participant_count: number
+}
+
+interface RankingsBare {
 	cursor: {
 		/**
 		 * The number of the next page, is null if no more results are available
 		 */
 		page: number | null
 	}
-	beatmapsets?: BeatmapsetExtended[]
-	spotlight?: Spotlight
+	/**
+	 * Total amount of elements available across all pages, not on this specific page! Maximum of 10000
+	 */
+	total: number
+}
+
+/**
+ * Expected from api.getRanking()
+ */
+export interface Rankings extends RankingsBare {
+	ranking: UserStatisticsWithUser[]
+}
+
+/**
+ * Expected from api.getCountryRanking()
+ * @remarks Not in the API's documentation
+ */
+export interface RankingsCountry extends RankingsBare {
+	ranking: {
+		/**
+		 * Same as `country.code`
+		 */
+		code: string
+		active_users: number
+		play_count: number
+		ranked_score: number
+		performance: number
+		country: {
+			/**
+			 * The country's ISO 3166-1 alpha-2 code! (France would be `FR`, United States `US`)
+			 */
+			code: string
+			name: string
+		}
+	}[]
+}
+
+/**
+ * Expected from api.getSpotlightRanking()
+ * @privateRemarks As this doesn't have `cursor` or `total`, this does NOT extend `Rankings` (which have those properties through `RankingsBare`)
+ */
+export interface RankingsSpotlight {
+	beatmapsets: BeatmapsetExtended[]
+	ranking: UserStatisticsWithUser[]
+	spotlight: SpotlightWithParticipantcount
 }

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -55,6 +55,17 @@ export interface Score {
 }
 
 /**
+ * Expected from Match
+ */
+export interface ScoreWithMatch extends Score {
+	match: {
+		slot: number
+		team: string
+		pass: boolean
+	}
+}
+
+/**
  * Expected from api.getBeatmapScores()
  */
 export interface ScoreWithUser extends Score {

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -1,5 +1,6 @@
-import { Beatmap, Beatmapset } from "./beatmap.js"
+import { BeatmapExtended, Beatmapset } from "./beatmap.js"
 import { Rulesets } from "./misc.js"
+import { User } from "./user.js"
 
 export interface Score {
 	id: number
@@ -37,15 +38,18 @@ export interface Score {
 	mode: string
 	mode_int: Rulesets
 	replay: boolean
-	beatmap?: Beatmap
+	beatmap?: BeatmapExtended
 	beatmapset?: Beatmapset
 	rank_country?: any
 	rank_global?: any
 	/**
-	 * @remarks Should only exist from the returned object of `getUserScores` if `type` is set to `best`
+	 * @remarks Only if `type` is set to `best` on `getUserScores`
 	 */
-	weight?: any
-	user?: any
+	weight?: {
+		percentage: number
+		pp: number
+	}
+	user?: User
 	match?: any
 	/**
 	 * @remarks Not in the API's documentation, expect it to either be unreliable or disappear 

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -1,25 +1,37 @@
 import { BeatmapExtended, Beatmapset } from "./beatmap.js"
 import { Rulesets } from "./misc.js"
-import { User } from "./user.js"
+import { User, UserWithCountryCover } from "./user.js"
 
+/**
+ * Expected from api.getBeatmapUserScores()
+ */
 export interface Score {
-	id: number
-	best_id: number
-	/**
-	 * The ID of the user who made the score
-	 */
-	user_id: number
 	/**
 	 * In a format where `96.40%` would be `0.9640` (likely with some numbers after the zero)
 	 */
 	accuracy: number
-	/**
-	 * 0 when NoMod
-	 */
-	mods: 0 | string[]
-	score: number
+	best_id: number
+	created_at: Date
+	id: number
 	max_combo: number
+	mode: string
+	mode_int: Rulesets
+	mods: string[]
+	passed: boolean
 	perfect: boolean
+	/**
+	 * null when Beatmap is Loved (for example)
+	 */
+	pp: null | number
+	/**
+	 * Also known as a grade, for example this is `X` (SS) if `accuracy` is `1` (100.00%)
+	 */
+	rank: string
+	/**
+	 * Can this score's replay be downloaded from the website?
+	 */
+	replay: boolean
+	score: number
 	statistics: {
 		count_50: number
 		count_100: number
@@ -28,20 +40,11 @@ export interface Score {
 		count_katu: number
 		count_miss: number
 	}
-	passed: boolean
+	type: string
 	/**
-	 * null when Beatmap is Loved (for example)
+	 * The ID of the user who made the score
 	 */
-	pp: null | number
-	rank: string
-	created_at: Date
-	mode: string
-	mode_int: Rulesets
-	replay: boolean
-	beatmap?: BeatmapExtended
-	beatmapset?: Beatmapset
-	rank_country?: any
-	rank_global?: any
+	user_id: number
 	/**
 	 * @remarks Only if `type` is set to `best` on `getUserScores`
 	 */
@@ -49,29 +52,38 @@ export interface Score {
 		percentage: number
 		pp: number
 	}
-	user?: User
-	match?: any
-	/**
-	 * @remarks Not in the API's documentation, expect it to either be unreliable or disappear 
-	 */
-	current_user_attributes?: {
-		/**
-		 * @remarks Seems to remain null even if the score is pinned on the user's profile
-		 */
-		pin: null
-	}
 }
 
+/**
+ * Expected from api.getBeatmapScores()
+ */
+export interface ScoreWithUser extends Score {
+	user: UserWithCountryCover
+}
+
+/**
+ * Expected from BeatmapUserScore
+ * @privateRemarks Doesn't extend ScoreWithUser as the User here lacks Country and Cover
+ */
+export interface ScoreWithUserBeatmap extends Score {
+	user: User
+	beatmap: BeatmapExtended
+}
+
+/**
+ * Expected from api.getUserScores()
+ */
+export interface ScoreWithUserBeatmapBeatmapset extends ScoreWithUserBeatmap {
+	beatmapset: Beatmapset
+}
+
+/**
+ * Expected from api.getBeatmapUserScore()
+ */
 export interface BeatmapUserScore {
 	/**
 	 * Value depends on the requested mode and mods!
 	 */
 	position: number
-	score: Score
-}
-
-export interface BeatmapScores {
-	scores: Score[]
-	userScore: BeatmapUserScore | null
-	user_score: BeatmapUserScore | null | undefined
+	score: ScoreWithUserBeatmap
 }

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -118,12 +118,12 @@ const testMultiplayerStuff = async (): Promise<boolean> => {
 	if (d1) { // can't bother getting and writing down the id of a playlist item
 		let d3 = await <Promise<ReturnType<typeof api.getPlaylistItemScores> | false>>attempt(
 			"getPlaylistItemScores (realtime): ", api.getPlaylistItemScores({id: d1.playlist[0].id, room_id: d1.id}))
-		!isOk(d3, !d3 || (d3.length > 0)) ? console.log("Bug not fixed yet...") : console.log("Bug fixed!!! :partying_face:")
+		!isOk(d3, !d3 || (d3.scores.length > 0)) ? console.log("Bug not fixed yet...") : console.log("Bug fixed!!! :partying_face:")
 	}
 	if (d2) { // still can't bother getting and writing down the id of a playlist item
 		let d4 = await <Promise<ReturnType<typeof api.getPlaylistItemScores> | false>>attempt(
 			"getPlaylistItemScores (playlist): ", api.getPlaylistItemScores({id: d2.playlist[0].id, room_id: d2.id}))
-		if (!isOk(d4, !d4 || (d4.length >= 50))) okay = false
+		if (!isOk(d4, !d4 || (d4.scores.length >= 50))) okay = false
 	}
 	let d5 = await <Promise<ReturnType<typeof api.getMatch> | false>>attempt("getMatch: ", api.getMatch(62006076))
 	if (!isOk(d5, !d5 || (d5.match.name === "CWC2020: (Italy) vs (Indonesia)"))) okay = false

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -76,12 +76,14 @@ const testBeatmapStuff = async (): Promise<boolean> => {
 	let b5 = await <Promise<ReturnType<typeof api.getBeatmapUserScores> | false>>attempt(
 		"getBeatmapUserScores: ", api.getBeatmapUserScores({id: 203993}, {id: 7276846}, osu.Rulesets.fruits))
 	if (!isOk(b5, !b5 || (b5.length === 1))) okay = false
-	let b6 = await <Promise<ReturnType<typeof api.getBeatmapset> | false>>attempt("getBeatmapset", api.getBeatmapset({id: 1971037}))
+	let b6 = await <Promise<ReturnType<typeof api.getBeatmapset> | false>>attempt("getBeatmapset: ", api.getBeatmapset({id: 1971037}))
 	if (!isOk(b6, !b6 || (b6.submitted_date?.toISOString().substring(0, 10) === "2023-04-07"))) okay = false
-	let b7 = await <Promise<ReturnType<typeof api.getBeatmapPack> | false>>attempt("getBeatmapPack", api.getBeatmapPack({tag: "P217"}))
+	let b7 = await <Promise<ReturnType<typeof api.getBeatmapPack> | false>>attempt("getBeatmapPack: ", api.getBeatmapPack({tag: "P217"}))
 	if (!isOk(b7, !b7 || (b7.tag === "P217"))) okay = false
-	let b8 = await <Promise<ReturnType<typeof api.getBeatmapPacks> | false>>attempt("getBeatmapPacks", api.getBeatmapPacks("tournament"))
+	let b8 = await <Promise<ReturnType<typeof api.getBeatmapPacks> | false>>attempt("getBeatmapPacks: ", api.getBeatmapPacks("tournament"))
 	if (!isOk(b8, !b8 || (b8.length >= 100))) okay = false
+	let b9 = await <Promise<ReturnType<typeof api.getBeatmapScores> | false>>attempt("getBeatmapScores: ", api.getBeatmapScores({id: 129891}))
+	if (!isOk(b9, !b9 || (b9[0].score >= 132408001))) okay = false
 
 	return okay
 }

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -142,8 +142,13 @@ const testRankingStuff = async (): Promise<boolean> => {
 	let e2 = await <Promise<ReturnType<typeof api.getRanking> | false>>attempt(
 		"getRanking: ", api.getRanking(osu.Rulesets.osu, "score", 1, "all", "FR"))
 	if (!isOk(e2, !e2 || (e2.ranking[0].level.current > 106))) okay = false
-	let e3 = await <Promise<ReturnType<typeof api.getSpotlights> | false>>attempt("getSpotlights: ", api.getSpotlights())
-	if (!isOk(e3, !e3 || (e3.length >= 132))) okay = false
+	let e3 = await <Promise<ReturnType<typeof api.getCountryRanking> | false>>attempt("getCountryRanking: ", api.getCountryRanking(osu.Rulesets.osu))
+	if (!isOk(e3, !e3 || (e3.ranking[0].code === "US"))) okay = false
+	let e4 = await <Promise<ReturnType<typeof api.getSpotlightRanking> | false>>attempt(
+		"getSpotlightRanking: ", api.getSpotlightRanking(osu.Rulesets.taiko, {id: 48}))
+	if (!isOk(e4, !e4 || (e4.ranking[0].hit_accuracy === 97.85))) okay = false
+	let e5 = await <Promise<ReturnType<typeof api.getSpotlights> | false>>attempt("getSpotlights: ", api.getSpotlights())
+	if (!isOk(e5, !e5 || (e5.length >= 132))) okay = false
 
 	return okay
 }

--- a/lib/tests/test_authorized.ts
+++ b/lib/tests/test_authorized.ts
@@ -16,17 +16,14 @@ async function test(id: string | undefined, secret: string | undefined, redirect
 	if (secret === undefined) {throw new Error("no SECRET env var")}
 	if (redirect_uri === undefined) {throw new Error("no REDIRECT_URI env var")}
 
-	let url = osu.generateAuthorizationURL(Number(id), redirect_uri, ["public"])
+	let url = osu.generateAuthorizationURL(Number(id), redirect_uri, ["public", "friends.read"])
 	exec(`xdg-open "${url}"`)
 	let code = prompt(`What code do you get from: ${url}\n\n`)
 
 	let api = await osu.API.createAsync({id: Number(id), secret}, {code, redirect_uri}, "all")
 	if (api) {
-		let d1 = await api.getRoom({id: 231069})
-		if (d1) {
-			let d2 = await api.getPlaylistItemScores({id: d1.playlist[0].id, room_id: 231069})
-			console.log(d2)
-		}
+		let a = await api.getResourceOwner()
+		console.log(util.inspect(a, false, null, true))
 	}
 }
 

--- a/lib/tests/test_authorized.ts
+++ b/lib/tests/test_authorized.ts
@@ -21,8 +21,8 @@ async function test(id: string | undefined, secret: string | undefined, redirect
 	let code = prompt(`What code do you get from: ${url}\n\n`)
 
 	let api = await osu.API.createAsync({id: Number(id), secret}, {code, redirect_uri}, "all")
-	let beatmap = await api.getBeatmap({id: 4118175})
-	console.log(beatmap)
+	let d2 = await api.getRoom({id: 464285})
+	let a = await api.getPlaylistItemScores({id: d2.playlist[0].id, room_id: d2.id})
 }
 
 test(process.env.ID, process.env.SECRET, process.env.REDIRECT_URI)

--- a/lib/tests/test_authorized.ts
+++ b/lib/tests/test_authorized.ts
@@ -4,10 +4,10 @@
  */
 
 import "dotenv/config"
+import * as osu from "../index.js"
 import promptSync from "prompt-sync"
 import { exec } from "child_process"
 import util from "util"
-import * as osu from "../index.js"
 
 const prompt = promptSync({sigint: true})
 
@@ -21,13 +21,8 @@ async function test(id: string | undefined, secret: string | undefined, redirect
 	let code = prompt(`What code do you get from: ${url}\n\n`)
 
 	let api = await osu.API.createAsync({id: Number(id), secret}, {code, redirect_uri}, "all")
-	if (api) {
-		let ranking = await api.getSpotlightRanking(osu.Rulesets.osu, {id: 271})
-		ranking.beatmapsets = [ranking.beatmapsets[0]]
-		ranking.ranking = [ranking.ranking[0]]
-		console.log(ranking)
-
-	}
+	let beatmap = await api.getBeatmap({id: 4118175})
+	console.log(beatmap)
 }
 
 test(process.env.ID, process.env.SECRET, process.env.REDIRECT_URI)

--- a/lib/tests/test_authorized.ts
+++ b/lib/tests/test_authorized.ts
@@ -22,8 +22,11 @@ async function test(id: string | undefined, secret: string | undefined, redirect
 
 	let api = await osu.API.createAsync({id: Number(id), secret}, {code, redirect_uri}, "all")
 	if (api) {
-		let a = await api.getResourceOwner()
-		console.log(util.inspect(a, false, null, true))
+		let ranking = await api.getSpotlightRanking(osu.Rulesets.osu, {id: 271})
+		ranking.beatmapsets = [ranking.beatmapsets[0]]
+		ranking.ranking = [ranking.ranking[0]]
+		console.log(ranking)
+
 	}
 }
 

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -8,8 +8,7 @@
 // unread_pm_count?: number
 // user_preferences?: any
 
-type ProfilePage = "me" | "recent_activity" | "beatmaps" |
-"historical" | "kudosu" | "top_ranks" | "medals"
+type ProfilePage = "me" | "recent_activity" | "beatmaps" | "historical" | "kudosu" | "top_ranks" | "medals"
 
 type UserBadge = {
 	awarded_at: Date
@@ -212,6 +211,8 @@ export interface UserStatistics {
 	count_300: number
 	count_50: number
 	count_miss: number
+	global_rank: number | null
+	global_rank_exp: number | null
 	grade_counts: {
 		a: number
 		s: number
@@ -219,6 +220,9 @@ export interface UserStatistics {
 		ss: number
 		ssh: number
 	}
+	/**
+	 * Accuracy in the normal format, where 96.56% would be `96.56`
+	 */
 	hit_accuracy: number
 	is_ranked: number
 	level: {
@@ -227,11 +231,9 @@ export interface UserStatistics {
 	}
 	maximum_combo: number
 	play_count: number
-	play_time: number
-	pp: number
+	play_time: number | null
+	pp: number | null
 	pp_exp: number
-	global_rank: number | null
-	global_rank_exp: number | null
 	ranked_score: number
 	replays_watched_by_others: number
 	total_hits: number

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,13 +1,3 @@
-// ORPHANS, SUPPOSED TO EXIST YET DON'T AFAIK
-// blocks?: any
-// friends?: any
-// is_restricted?: boolean | null
-// /**
-//  * @remarks ...I actually don't know its type and have been unable to figure it out, I'm only presuming it is number
-//  */
-// unread_pm_count?: number
-// user_preferences?: any
-
 type ProfilePage = "me" | "recent_activity" | "beatmaps" | "historical" | "kudosu" | "top_ranks" | "medals"
 
 type UserBadge = {
@@ -23,6 +13,9 @@ type ProfileBanner = {
 	image: string
 }
 
+/**
+ * Expected from BeatmapsetExtendedPlus, Room
+ */
 export interface User {
 	avatar_url: string
 	country_code: string
@@ -60,7 +53,7 @@ export interface UserWithCountry extends User {
 }
 
 /**
- * Expected from UserStatisticsWithUser, MultiplayerScore
+ * Expected from UserStatisticsWithUser, MultiplayerScore, ScoreWithUser
  */
 export interface UserWithCountryCover extends UserWithCountry {
 	cover: {

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,3 +1,13 @@
+// ORPHANS, SUPPOSED TO EXIST YET DON'T AFAIK
+// blocks?: any
+// friends?: any
+// is_restricted?: boolean | null
+// /**
+//  * @remarks ...I actually don't know its type and have been unable to figure it out, I'm only presuming it is number
+//  */
+// unread_pm_count?: number
+// user_preferences?: any
+
 type ProfilePage = "me" | "recent_activity" | "beatmaps" |
 "historical" | "kudosu" | "top_ranks" | "medals"
 
@@ -28,33 +38,41 @@ export interface User {
 	pm_friends_only: boolean
 	profile_colour: string | null
 	username: string
+}
 
-	account_history?: {
-		description: string | null
-		id: number
-		length: number
-		permanent: boolean
-		timestamp: Date
-		type: "note" | "restriction" | "silence"
-	}[] | 0
-	active_tournament_banner?: ProfileBanner | null
-	badges?: UserBadge[] | 0
-	beatmap_playcounts_count?: number
-	blocks?: any
-	country?: {
+/**
+ * Expected from api.getKudosuRanking()
+ */
+export interface UserWithKudosu extends User {
+	kudosu: {
+		available: number
+		total: number
+	}
+}
+
+/**
+ * Expected from api.getMatch(), Leader
+ */
+export interface UserWithCountry extends User {
+	country: {
 		code: string
 		name: string
 	}
-	cover?: {
+}
+
+/**
+ * Expected from UserStatisticsWithUser, MultiplayerScore
+ */
+export interface UserWithCountryCover extends UserWithCountry {
+	cover: {
 		custom_url: string | null
 		url: string
 		id: string | null
 	}
-	favourite_beatmapset_count?: number
-	follower_count?: number
-	friends?: any
-	graveyard_beatmapset_count?: number
-	groups?: {
+}
+
+interface UserWithCountryCoverGroups extends UserWithCountryCover {
+	groups: {
 		colour: string | null
 		has_listing: boolean
 		has_playmodes: boolean
@@ -64,76 +82,38 @@ export interface User {
 		name: string
 		playmodes: string[] | null
 		short_name: string
-	}[] | 0
-	is_restricted?: boolean | null
-	kudosu?: {
-		available: number
-		total: number
-	}
-	loved_beatmapset_count?: number
-	monthly_playcounts?: {
-		start_date: Date
-		count: number
 	}[]
-	page?: {
-		html: string
-		raw: string
-	}
-	pending_beatmapset_count?: number
-	previous_usernames?: string[]
-	rank_highest?: {
-		rank: number
-		updated_at: Date
-	} | null
-	rank_history?: {
-		mode: string
-		data: number[]
-	}
-	ranked_beatmapset_count?: number
-	replays_watched_counts?: {
-		start_date: Date
-		count: number
-	}[]
-	scores_best_count?: number
-	scores_recent_count?: number
-	statistics?: UserStatistics
-	statistics_rulesets?: {
+}
+
+/**
+ * Expected from api.getUsers()
+ */
+export interface UserWithCountryCoverGroupsStatisticsrulesets extends UserWithCountryCoverGroups {
+	statistics_rulesets: {
 		osu: UserStatistics
 		taiko: UserStatistics
 		fruits: UserStatistics
 		mania: UserStatistics
 	}
-	support_level?: number
-	/**
-	 * @remarks ...I actually don't know its type and have been unable to figure it out, I'm only presuming it is number
-	 */
-	unread_pm_count?: number
-	user_achievements?: {
-		achieved_at: Date
-		achievement_id: number
-	}[]
-	user_preferences?: any
 }
 
-export interface UserExtended extends User {
-	country: {
-		code: string
-		name: string
-	}
-	cover: {
-		custom_url: string | null
-		url: string
-		id: string | null
-	}
+/**
+ * Expected from api.getFriends()
+ */
+export interface UserWithCountryCoverGroupsStatisticsSupport extends UserWithCountryCoverGroups {
+	statistics: UserStatistics
+	support_level: number
+}
+
+/**
+ * Expected from api.getUser()
+ */
+export interface UserExtended extends UserWithCountryCoverGroupsStatisticsSupport, UserWithKudosu {
 	cover_url: string
 	discord: string | null
 	has_supported: boolean
 	interests: string | null
 	join_date: Date
-	kudosu: {
-		available: number
-		total: number
-	}
 	location: string | null
 	max_blocks: number
 	max_friends: number
@@ -146,6 +126,85 @@ export interface UserExtended extends User {
 	title_url: string | null
 	twitter: string | null
 	website: string | null
+	account_history: {
+		description: string | null
+		id: number
+		length: number
+		permanent: boolean
+		timestamp: Date
+		type: "note" | "restriction" | "silence"
+	}[]
+	active_tournament_banner: ProfileBanner | null
+	/**
+	 * This is not documented by osu!, likely because support for multiple banners has been recently added (OWC2023)
+	 */
+	active_tournament_banners: ProfileBanner[]
+	badges: UserBadge[]
+	beatmap_playcounts_count: number
+	comments_count: number
+	favourite_beatmapset_count: number
+	follower_count: number
+	graveyard_beatmapset_count: number
+	groups: {
+		colour: string | null
+		has_listing: boolean
+		has_playmodes: boolean
+		id: number
+		identifier: string
+		is_probationary: boolean
+		name: string
+		playmodes: string[] | null
+		short_name: string
+	}[]
+	guest_beatmapset_count: number
+	loved_beatmapset_count: number
+	mapping_follower_count: number
+	monthly_playcounts: {
+		start_date: Date
+		count: number
+	}[]
+	nominated_beatmapset_count: number
+	page: {
+		html: string
+		/**
+		 * Basically the text with the BBCode
+		 */
+		raw: string
+	}
+	pending_beatmapset_count: number
+	previous_usernames: string[]
+	rank_highest: {
+		rank: number
+		updated_at: Date
+	} | null
+	replays_watched_counts: {
+		start_date: Date
+		count: number
+	}[]
+	scores_best_count: number
+	scores_first_count: number
+	/**
+	 * Specific to the Ruleset (`playmode`)
+	 */
+	scores_pinned_count: number
+	scores_recent_count: number
+	statistics: UserStatisticsWithCountryrank
+	support_level: number
+	user_achievements: {
+		achieved_at: Date
+		achievement_id: number
+	}[]
+	rank_history: {
+		mode: string
+		data: number[]
+	}
+}
+
+/**
+ * Expected from api.getResourceOwner()
+ */
+export interface UserExtendedWithStatisticsrulesets extends UserExtended, UserWithCountryCoverGroupsStatisticsrulesets {
+	
 }
 
 export interface UserStatistics {
@@ -177,7 +236,20 @@ export interface UserStatistics {
 	replays_watched_by_others: number
 	total_hits: number
 	total_score: number
-	user: User
+}
+
+/**
+ * Expected from UserExtended
+ */
+export interface UserStatisticsWithCountryrank extends UserStatistics {
+	country_rank: number
+}
+
+/**
+ * Expected from Rankings
+ */
+export interface UserStatisticsWithUser extends UserStatisticsWithCountryrank {
+	user: UserWithCountryCover
 }
 
 export interface KudosuHistory {


### PR DESCRIPTION
Optional properties have always been something I disliked with this package
In my opinion, they make it almost impossible to predict what properties will be in the received object

This PR aims to deal with that issue by making many interfaces that extend other interfaces, and use each of them (kinda) as the return type of the different functions this package offers
For example, there's now a distinction between what kind of object `api.getUser()` and `api.getResourceOwner()` returns to you, even if they remain closely related thanks to interface extensions