### PR TITLE
Make tests check if objects match their interface

### DIFF
--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -104,12 +104,16 @@ export interface Beatmapset {
 	favourite_count: number
 	id: number
 	nsfw: boolean
+	offset: number
 	play_count: number
 	/**
 	 * A string like that, where id is the `id` of the beatmapset: `//b.ppy.sh/preview/58951.mp3`
 	 */
 	preview_url: string
-	source: string
+	/**
+	 * Can be/Is 0 if there is no source
+	 */
+	source: string | 0
 	spotlight: boolean
 	/**
 	 * Is it ranked, is it graveyarded, etc

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -1,8 +1,7 @@
-export interface ChangelogBuild {
+interface ChangelogBuild {
 	created_at: Date
 	display_version: string
 	id: number
-	update_stream: UpdateStream | null
 	/**
 	 * How many users are playing on this version of the game? (if lazer/web, should be 0, lazer doesn't show such stats)
 	 */
@@ -16,28 +15,33 @@ export interface ChangelogBuild {
 	 * @remarks The ID of a Youtube video is whatever comes after `/watch?v=` in its url
 	 */
 	youtube_id: string | null
-	changelog_entries?: {
+}
+
+/**
+ * Expected from ChangelogBuildWithChangelogentriesVersions
+ */
+export interface ChangelogBuildWithUpdatestreams extends ChangelogBuild {
+	update_stream: UpdateStream
+}
+
+interface ChangelogBuildWithChangelogentries extends ChangelogBuild {
+	changelog_entries: {
+		id: number | null
+		repository: string | null
+		github_pull_request_id: number | null
+		github_url: string | null
+		url: string | null
+		type: string
 		category: string
+		title: string | null
+		major: boolean
 		/**
 		 * Can be January 1st 1970!
 		 */
-		created_at: Date | null
-		github_pull_request_id: number | null
-		github_url: string | null
-		id: number | null
-		major: boolean
-		repository: string | null
-		title: string | null
-		type: string
-		url: string | null
+		created_at: Date
 		/**
-		 * Entry message in Markdown format, embedded HTML is allowed, exists only if Markdown was requested
+		 * Doesn't exist if no github user is associated with who's credited with the change
 		 */
-		message?: string | null
-		/**
-		 * Entry message in HTML format, exists only if HTML was requested
-		 */
-		message_html?: string | null
 		github_user?: {
 			display_name: string
 			github_url: string | null
@@ -47,21 +51,49 @@ export interface ChangelogBuild {
 			user_id: number | null
 			user_url: string | null
 		}
-	}
-	/**
-	 * The ChangelogBuilds in `versions` will not have `changelog_entries` or `versions`, and `users` will be 0
-	 */
-	versions?: {
-		next: ChangelogBuild | null
-		previous: ChangelogBuild | null
+		/**
+		 * Entry message in Markdown format, embedded HTML is allowed, exists only if Markdown was requested
+		 */
+		message?: string | null
+		/**
+		 * Entry message in HTML format, exists only if HTML was requested
+		 */
+		message_html?: string | null
+		
+	}[]
+}
+
+/**
+ * Expected from api.getChangelogBuilds()
+ */
+export interface ChangelogBuildWithUpdatestreamsChangelogentries extends ChangelogBuildWithUpdatestreams, ChangelogBuildWithChangelogentries {
+
+}
+
+/**
+ * Expected from api.getChangelogBuild()
+ */
+export interface ChangelogBuildWithChangelogentriesVersions extends ChangelogBuildWithChangelogentries {
+	versions: {
+		next: ChangelogBuildWithUpdatestreams | null
+		previous: ChangelogBuildWithUpdatestreams | null
 	}
 }
 
+/**
+ * Expected from ChangelogBuildWithUpdatestreams
+ */
 export interface UpdateStream {
-	display_name: string | null
 	id: number
-	is_featured: boolean
 	name: string
+	display_name: string | null
+	is_featured: boolean
+}
+
+/**
+ * Expected from api.getChangelogStreams()
+ */
+export interface UpdateStreamWithLatestbuildUsercount extends UpdateStream {
 	latest_build: ChangelogBuild | null
 	/**
 	 * How many users are playing on this? (if lazer/web, should be 0, lazer doesn't show such stats)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,14 +6,14 @@ import { Leader, Match, MatchInfo, MultiplayerScore, MultiplayerScores, Playlist
 import { Rulesets, Mod } from "./misc.js"
 import { BeatmapUserScore, Score, ScoreWithUser, ScoreWithUserBeatmapBeatmapset } from "./score.js"
 import { Rankings, RankingsCountry, RankingsSpotlight, Spotlight } from "./ranking.js"
-import { ChangelogBuild, UpdateStream } from "./changelog.js"
+import { ChangelogBuildWithChangelogentriesVersions, ChangelogBuildWithUpdatestreamsChangelogentries, UpdateStream } from "./changelog.js"
 
 export {User, UserExtended, KudosuHistory}
 export {Beatmap, BeatmapExtended, Beatmapset, BeatmapsetExtended}
 export {BeatmapUserScore, Score}
 export {Room, Leader, PlaylistItem, MultiplayerScore}
 export {Rulesets}
-export {ChangelogBuild, UpdateStream}
+export {UpdateStream}
 
 /**
  * Scopes determine what the API instance can do as a user!
@@ -465,9 +465,9 @@ export class API {
 	 * @param stream The name of the thing related to osu!, like `lazer`, `web`, `cuttingedge`, `beta40`, `stable40`
 	 * @param build The name of the version! Usually something like `2023.1026.0` for lazer, or `20230326` for stable
 	 */
-	async getChangelogBuild(stream: string, build: string): Promise<ChangelogBuild> {
+	async getChangelogBuild(stream: string, build: string): Promise<ChangelogBuildWithChangelogentriesVersions> {
 		const response = await this.request("get", `changelog/${stream}/${build}`)
-		return correctType(response) as ChangelogBuild
+		return correctType(response) as ChangelogBuildWithChangelogentriesVersions
 	}
 
 	/**
@@ -478,10 +478,10 @@ export class API {
 	 * @param message_formats Each element of `changelog_entries` will have a `message` property if `markdown`, `message_html` if `html`, defaults to both
 	 */
 	async getChangelogBuilds(versions?: {from?: string, to?: string}, max_id?: number,
-	stream?: string, message_formats: ("html" | "markdown")[] = ["html", "markdown"]): Promise<ChangelogBuild[]> {
+	stream?: string, message_formats: ("html" | "markdown")[] = ["html", "markdown"]): Promise<ChangelogBuildWithUpdatestreamsChangelogentries[]> {
 		const [from, to] = [versions?.from, versions?.to]
 		const response = await this.request("get", "changelog", {from, to, max_id, stream, message_formats})
-		return response.builds.map((b: ChangelogBuild) => correctType(b)) as ChangelogBuild[]
+		return response.builds.map((b: ChangelogBuildWithUpdatestreamsChangelogentries) => correctType(b)) as ChangelogBuildWithUpdatestreamsChangelogentries[]
 	}
 
 	/**
@@ -642,7 +642,7 @@ function correctType(x: any): any {
 		const k = Object.keys(x)
 		const v = Object.values(x)
 		for (let i = 0; i < k.length; i++) {
-			if (k[i].includes("name") || k[i].includes("version")) continue // don't turn names made of numbers into integers
+			if (typeof v[i] === "string" && (k[i].includes("name") || k[i].includes("version"))) continue // don't turn names made of numbers into integers
 			x[k[i]] = correctType(v[i])
 		}
 	}

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -10,7 +10,7 @@ export interface Score {
 	 * In a format where `96.40%` would be `0.9640` (likely with some numbers after the zero)
 	 */
 	accuracy: number
-	best_id: number
+	best_id: number | null
 	created_at: Date
 	id: number
 	max_combo: number

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -6,7 +6,6 @@
 import * as osu from "../index.js"
 import "dotenv/config"
 import util from "util"
-// console.log(util.inspect(users, false, null, true))
 
 import tsj from "ts-json-schema-generator"
 import ajv from "ajv"
@@ -30,12 +29,13 @@ async function attempt<T>(msg: string, fun: Promise<any>): Promise<T | false> {
 function isOk(response: any, condition?: boolean) {
 	if (condition === undefined) condition = true
 	if (!response || !condition) {
-		console.error("❌ Bad response:", response)
+		console.error("❌ Bad response:", util.inspect(response, {colors: true, compact: true, breakLength: 400, depth: Infinity}))
 		return false
 	}
 	return true
 }
 
+// ajv will not work properly if type is not changed from string to object where format is date-time
 function fixDate(x: any) {
 	if (typeof x === "object" && x !== null) {
 		if (x["format"] && x["format"] === "date-time" && x["type"] && x["type"] === "string") {
@@ -52,36 +52,44 @@ function fixDate(x: any) {
 	return x
 }
 
-function validate<T>(file: string, object: T): boolean {
-	const schema = fixDate(tsj.createGenerator({path: `lib/${file}.ts`, additionalProperties: true}).createSchema("User"))
-	const ajv_const = new ajv.default({strict: false})
-	ajv_const.addFormat("date-time", true)
-	
-	let validator = ajv_const.compile<T>(schema)
-	let result = validator(object)
-	if (validator.errors) console.log(validator.errors)
-	return result
+// Creating a Generator takes 3 to 5 seconds, so it's better not to create one each time we call the validate function
+function validate(object: unknown, schemaName: string, generator: tsj.SchemaGenerator): boolean {
+	try {
+		const schema = fixDate(generator.createSchema(schemaName))
+		const ajv_const = new ajv.default({strict: false})
+		ajv_const.addFormat("date-time", true)
+		
+		let validator = ajv_const.compile(schema)
+		let result = validator(object)
+		if (validator.errors) console.error(validator.errors)
+		return result
+	} catch(err) {
+		console.log(err)
+		return true
+	}
 }
 
 /**
  * Check if getUser() and similar work fine 
  */
 const testUserStuff = async (): Promise<boolean> => {
+	const generator = tsj.createGenerator({path: "lib/user.ts", additionalProperties: true})
+	const score_gen = tsj.createGenerator({path: "lib/score.ts", additionalProperties: true})
 	const user_id = 7276846
 	let okay = true
 	
 	let a1 = await <Promise<ReturnType<typeof api.getUser> | false>>attempt("\ngetUser: ", api.getUser({id: user_id}))
-	if (!isOk(a1, !a1 || validate<Awaited<ReturnType<typeof api.getUser>>>("user", a1) || (a1.id === user_id))) okay = false
+	if (!isOk(a1, !a1 || (a1.id === user_id && validate(a1, "UserExtended", generator)))) okay = false
 	let a2 = await <Promise<ReturnType<typeof api.getUsers> | false>>attempt("getUsers: ", api.getUsers([user_id, 2]))
-	if (!isOk(a2, !a2 || (a2.length === 2))) okay = false
+	if (!isOk(a2, !a2 || (a2.length === 2 && validate(a2[0], "User", generator)))) okay = false
 	let a3 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores: ", api.getUserScores({id: user_id}, "best", 5))
-	if (!isOk(a3, !a3 || (a3.length === 5))) okay = false
+	if (!isOk(a3, !a3 || (a3.length === 5 && validate(a3[0], "Score", score_gen)))) okay = false
 	let a4 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores: ", api.getUserScores({id: user_id}, "firsts", 5))
 	if (!isOk(a4, !a4 || (a4.length === 0))) okay = false
 	let a5 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores: ", api.getUserScores({id: user_id}, "recent", 5))
 	if (!isOk(a5)) okay = false
 	let a6 = await <Promise<ReturnType<typeof api.getUserKudosu> | false>>attempt("getUserKudosu: ", api.getUserKudosu({id: user_id}, 5))
-	if (!isOk(a6, !a6 || (a6.length === 5))) okay = false
+	if (!isOk(a6, !a6 || (a6.length === 5 && validate(a6[0], "KudosuHistory", generator)))) okay = false
 
 	return okay
 }
@@ -90,28 +98,30 @@ const testUserStuff = async (): Promise<boolean> => {
  * Check if getBeatmap() and similar work fine 
  */
 const testBeatmapStuff = async (): Promise<boolean> => {
+	const generator = tsj.createGenerator({path: "lib/beatmap.ts", additionalProperties: true})
+	const score_gen = tsj.createGenerator({path: "lib/score.ts", additionalProperties: true})
 	const beatmap_id = 388463
 	let okay = true
 
 	let b1 = await <Promise<ReturnType<typeof api.getBeatmap> | false>>attempt("\ngetBeatmap: ", api.getBeatmap({id: beatmap_id}))
-	if (!isOk(b1, !b1 || (b1.id === beatmap_id))) okay = false
+	if (!isOk(b1, !b1 || (b1.id === beatmap_id && validate(b1, "BeatmapExtended", generator)))) okay = false
 	let b2 = await <Promise<ReturnType<typeof api.getBeatmaps> | false>>attempt("getBeatmaps: ", api.getBeatmaps([beatmap_id, 4089655]))
-	if (!isOk(b2, !b2 || (b2.length === 2))) okay = false
+	if (!isOk(b2, !b2 || (b2.length === 2 && validate(b2[0], "BeatmapExtended", generator)))) okay = false
 	let b3 = await <Promise<ReturnType<typeof api.getBeatmapDifficultyAttributes> | false>>attempt(
 		"getBeatmapAttributes: ", api.getBeatmapDifficultyAttributes({id: beatmap_id}, ["DT"]))
-	if (!isOk(b3, !b3 || (b3.great_hit_window < 35))) okay = false
+	if (!isOk(b3, !b3 || (b3.great_hit_window < 35 && validate(b3, "BeatmapDifficultyAttributes", generator)))) okay = false
 	let b4 = await <Promise<ReturnType<typeof api.getBeatmapUserScore> | false>>attempt(
 		"getBeatmapUserScore: ", api.getBeatmapUserScore({id: 176960}, {id: 7276846}, ["NM"]))
-	if (!isOk(b4, !b4 || (b4.score.accuracy < 0.99))) okay = false
+	if (!isOk(b4, !b4 || (b4.score.accuracy < 0.99 && validate(b4, "BeatmapUserScore", score_gen)))) okay = false
 	let b5 = await <Promise<ReturnType<typeof api.getBeatmapUserScores> | false>>attempt(
 		"getBeatmapUserScores: ", api.getBeatmapUserScores({id: 203993}, {id: 7276846}, osu.Rulesets.fruits))
-	if (!isOk(b5, !b5 || (b5.length === 1))) okay = false
-	let b6 = await <Promise<ReturnType<typeof api.getBeatmapset> | false>>attempt("getBeatmapset", api.getBeatmapset({id: 1971037}))
-	if (!isOk(b6, !b6 || (b6.submitted_date?.toISOString().substring(0, 10) === "2023-04-07"))) okay = false
-	let b7 = await <Promise<ReturnType<typeof api.getBeatmapPack> | false>>attempt("getBeatmapPack", api.getBeatmapPack({tag: "P217"}))
-	if (!isOk(b7, !b7 || (b7.tag === "P217"))) okay = false
-	let b8 = await <Promise<ReturnType<typeof api.getBeatmapPacks> | false>>attempt("getBeatmapPacks", api.getBeatmapPacks("tournament"))
-	if (!isOk(b8, !b8 || (b8.length >= 100))) okay = false
+	if (!isOk(b5, !b5 || (b5.length === 1 && validate(b5[0], "Score", score_gen)))) okay = false
+	let b6 = await <Promise<ReturnType<typeof api.getBeatmapset> | false>>attempt("getBeatmapset: ", api.getBeatmapset({id: 1971037}))
+	if (!isOk(b6, !b6 || (b6.submitted_date?.toISOString().substring(0, 10) === "2023-04-07", validate(b6, "BeatmapsetExtended", generator)))) okay = false
+	let b7 = await <Promise<ReturnType<typeof api.getBeatmapPack> | false>>attempt("getBeatmapPack: ", api.getBeatmapPack({tag: "P217"}))
+	if (!isOk(b7, !b7 || (b7.tag === "P217" && validate(b7, "BeatmapPack", generator)))) okay = false
+	let b8 = await <Promise<ReturnType<typeof api.getBeatmapPacks> | false>>attempt("getBeatmapPacks: ", api.getBeatmapPacks("tournament"))
+	if (!isOk(b8, !b8 || (b8.length >= 100 && validate(b8[0], "BeatmapPack", generator)))) okay = false
 
 	return okay
 }
@@ -120,15 +130,16 @@ const testBeatmapStuff = async (): Promise<boolean> => {
  * Check if getChangelogBuild() and similar work fine 
  */
 const testChangelogStuff = async (): Promise<boolean> => {
+	const generator = tsj.createGenerator({path: "lib/changelog.ts", additionalProperties: true})
 	let okay = true
 
 	let c1 = await <Promise<ReturnType<typeof api.getChangelogBuild> | false>>attempt("\ngetChangelogBuild: ", api.getChangelogBuild("lazer", "2023.1008.1"))
-	if (!isOk(c1, !c1 || (c1.id === 7156))) okay = false
+	if (!isOk(c1, !c1 || (c1.id === 7156 && validate(c1, "ChangelogBuild", generator)))) okay = false
 	let c2 = await <Promise<ReturnType<typeof api.getChangelogBuilds> | false>>attempt(
 		"getChangelogBuilds: ", api.getChangelogBuilds({from: "2023.1031.0", to: "20231102.3"}, 7184, undefined, ["markdown"]))
-	if (!isOk(c2, !c2 || (c2.length === 4))) okay = false
+	if (!isOk(c2, !c2 || (c2.length === 4 && validate(c2[0], "ChangelogBuild", generator)))) okay = false
 	let c3 = await <Promise<ReturnType<typeof api.getChangelogStreams> | false>>attempt("getChangelogStreams: ", api.getChangelogStreams())
-	if (!isOk(c3, !c3 || (c3.length > 2))) okay = false
+	if (!isOk(c3, !c3 || (c3.length > 2 && validate(c3[0], "UpdateStream", generator)))) okay = false
 
 	return okay
 }
@@ -137,26 +148,28 @@ const testChangelogStuff = async (): Promise<boolean> => {
  * Check if getRoom(), getMatch() and similar work fine
  */
 const testMultiplayerStuff = async (): Promise<boolean> => {
+	const generator = tsj.createGenerator({path: "lib/multiplayer.ts", additionalProperties: true})
 	let okay = true
 
 	let d1 = await <Promise<ReturnType<typeof api.getRoom> | false>>attempt("\ngetRoom (realtime): ", api.getRoom({id: 231069}))
-	if (!isOk(d1, !d1 || (d1.recent_participants.length === 4))) okay = false
+	if (!isOk(d1, !d1 || (d1.recent_participants.length === 4 && validate(d1, "Room", generator)))) okay = false
 	let d2 = await <Promise<ReturnType<typeof api.getRoom> | false>>attempt("getRoom (playlist): ", api.getRoom({id: 51693}))
-	if (!isOk(d2, !d2 || (d2.participant_count === 159))) okay = false
+	if (!isOk(d2, !d2 || (d2.participant_count === 159 && validate(d2, "Room", generator)))) okay = false
 	if (d1) { // can't bother getting and writing down the id of a playlist item
 		let d3 = await <Promise<ReturnType<typeof api.getPlaylistItemScores> | false>>attempt(
 			"getPlaylistItemScores (realtime): ", api.getPlaylistItemScores({id: d1.playlist[0].id, room_id: d1.id}))
-		!isOk(d3, !d3 || (d3.length > 0)) ? console.log("Bug not fixed yet...") : console.log("Bug fixed!!! :partying_face:")
+		!isOk(d3, !d3 || (d3.length > 0 && validate(d3[0], "MultiplayerScore", generator))) ?
+			console.log("Bug not fixed yet...") : console.log("Bug fixed!!! :partying_face:")
 	}
 	if (d2) { // still can't bother getting and writing down the id of a playlist item
 		let d4 = await <Promise<ReturnType<typeof api.getPlaylistItemScores> | false>>attempt(
 			"getPlaylistItemScores (playlist): ", api.getPlaylistItemScores({id: d2.playlist[0].id, room_id: d2.id}))
-		if (!isOk(d4, !d4 || (d4.length >= 50))) okay = false
+		if (!isOk(d4, !d4 || (d4.length >= 50 && validate(d4[0], "MultiplayerScore", generator)))) okay = false
 	}
 	let d5 = await <Promise<ReturnType<typeof api.getMatch> | false>>attempt("getMatch: ", api.getMatch(62006076))
-	if (!isOk(d5, !d5 || (d5.match.name === "CWC2020: (Italy) vs (Indonesia)"))) okay = false
+	if (!isOk(d5, !d5 || (d5.match.name === "CWC2020: (Italy) vs (Indonesia)" && validate(d5, "Match", generator)))) okay = false
 	let d6 = await <Promise<ReturnType<typeof api.getMatches> | false>>attempt("getMatches: ", api.getMatches())
-	if (!isOk(d6, !d6 || (d6[0].id > 111250329))) okay = false
+	if (!isOk(d6, !d6 || (d6[0].id > 111250329 && validate(d6[0], "MatchInfo", generator)))) okay = false
 
 	return okay
 }
@@ -165,15 +178,16 @@ const testMultiplayerStuff = async (): Promise<boolean> => {
  * Check if getRanking() and similar work fine
  */
 const testRankingStuff = async (): Promise<boolean> => {
+	const generator = tsj.createGenerator({path: "lib/ranking.ts", additionalProperties: true})
 	let okay = true
 
 	let e1 = await <Promise<ReturnType<typeof api.getKudosuRanking> | false>>attempt("\ngetKudosuRanking: ", api.getKudosuRanking())
-	if (!isOk(e1, !e1 || (e1[0].kudosu!.total > 10000))) okay = false
+	if (!isOk(e1, !e1 || (e1[0].kudosu!.total > 10000 && validate(e1[0], "User", generator)))) okay = false
 	let e2 = await <Promise<ReturnType<typeof api.getRanking> | false>>attempt(
 		"getRanking: ", api.getRanking(osu.Rulesets.osu, "score", 1, "all", "FR"))
-	if (!isOk(e2, !e2 || (e2.ranking[0].level.current > 106))) okay = false
+	if (!isOk(e2, !e2 || (e2.ranking[0].level.current > 106 && validate(e2, "Rankings", generator)))) okay = false
 	let e3 = await <Promise<ReturnType<typeof api.getSpotlights> | false>>attempt("getSpotlights: ", api.getSpotlights())
-	if (!isOk(e3, !e3 || (e3.length >= 132))) okay = false
+	if (!isOk(e3, !e3 || (e3.length >= 132 && validate(e3[0], "Spotlight", generator)))) okay = false
 
 	return okay
 }

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -137,12 +137,12 @@ const testChangelogStuff = async (): Promise<boolean> => {
 	let okay = true
 
 	let c1 = await <Promise<ReturnType<typeof api.getChangelogBuild> | false>>attempt("\ngetChangelogBuild: ", api.getChangelogBuild("lazer", "2023.1008.1"))
-	if (!isOk(c1, !c1 || (c1.id === 7156 && validate(c1, "ChangelogBuild", generator)))) okay = false
+	if (!isOk(c1, !c1 || (c1.id === 7156 && validate(c1, "ChangelogBuildWithChangelogentriesVersions", generator)))) okay = false
 	let c2 = await <Promise<ReturnType<typeof api.getChangelogBuilds> | false>>attempt(
 		"getChangelogBuilds: ", api.getChangelogBuilds({from: "2023.1031.0", to: "20231102.3"}, 7184, undefined, ["markdown"]))
-	if (!isOk(c2, !c2 || (c2.length === 4 && validate(c2[0], "ChangelogBuild", generator)))) okay = false
+	if (!isOk(c2, !c2 || (c2.length === 4 && validate(c2[0], "ChangelogBuildWithUpdatestreamsChangelogentries", generator)))) okay = false
 	let c3 = await <Promise<ReturnType<typeof api.getChangelogStreams> | false>>attempt("getChangelogStreams: ", api.getChangelogStreams())
-	if (!isOk(c3, !c3 || (c3.length > 2 && validate(c3[0], "UpdateStream", generator)))) okay = false
+	if (!isOk(c3, !c3 || (c3.length > 2 && validate(c3[0], "UpdateStreamWithLatestbuildUsercount", generator)))) okay = false
 
 	return okay
 }

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -81,13 +81,14 @@ const testUserStuff = async (): Promise<boolean> => {
 	let a1 = await <Promise<ReturnType<typeof api.getUser> | false>>attempt("\ngetUser: ", api.getUser({id: user_id}))
 	if (!isOk(a1, !a1 || (a1.id === user_id && validate(a1, "UserExtended", generator)))) okay = false
 	let a2 = await <Promise<ReturnType<typeof api.getUsers> | false>>attempt("getUsers: ", api.getUsers([user_id, 2]))
-	if (!isOk(a2, !a2 || (a2.length === 2 && validate(a2[0], "User", generator)))) okay = false
-	let a3 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores: ", api.getUserScores({id: user_id}, "best", 5))
-	if (!isOk(a3, !a3 || (a3.length === 5 && validate(a3[0], "Score", score_gen)))) okay = false
-	let a4 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores: ", api.getUserScores({id: user_id}, "firsts", 5))
-	if (!isOk(a4, !a4 || (a4.length === 0))) okay = false
-	let a5 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores: ", api.getUserScores({id: user_id}, "recent", 5))
-	if (!isOk(a5)) okay = false
+	if (!isOk(a2, !a2 || (a2.length === 2 && validate(a2[0], "UserWithCountryCoverGroupsStatisticsrulesets", generator)))) okay = false
+	let a3 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores (best): ", api.getUserScores({id: user_id}, "best", 5))
+	if (!isOk(a3, !a3 || (a3.length === 5 && validate(a3[0], "ScoreWithUserBeatmapBeatmapset", score_gen)))) okay = false
+	let a4 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores (firsts): ", api.getUserScores({id: 6503700}, "firsts", 3))
+	if (!isOk(a4, !a4 || (a4.length === 3 && validate(a4[0], "ScoreWithUserBeatmapBeatmapset", score_gen)))) okay = false
+	let a5 = await <Promise<ReturnType<typeof api.getUserScores> | false>>attempt("getUserScores (recent): ", api.getUserScores({id: 12337864}, "recent", 1))
+	// Due to the nature of the test, it might fail, you may adapt the user id
+	if (!isOk(a5, !a5 || (a5.length === 1 && validate(a5[0], "ScoreWithUserBeatmapBeatmapset", score_gen)))) okay = false
 	let a6 = await <Promise<ReturnType<typeof api.getUserKudosu> | false>>attempt("getUserKudosu: ", api.getUserKudosu({id: user_id}, 5))
 	if (!isOk(a6, !a6 || (a6.length === 5 && validate(a6[0], "KudosuHistory", generator)))) okay = false
 
@@ -104,7 +105,7 @@ const testBeatmapStuff = async (): Promise<boolean> => {
 	let okay = true
 
 	let b1 = await <Promise<ReturnType<typeof api.getBeatmap> | false>>attempt("\ngetBeatmap: ", api.getBeatmap({id: beatmap_id}))
-	if (!isOk(b1, !b1 || (b1.id === beatmap_id && validate(b1, "BeatmapExtended", generator)))) okay = false
+	if (!isOk(b1, !b1 || (b1.id === beatmap_id && validate(b1, "BeatmapExtendedWithFailtimesBeatmapsetextended", generator)))) okay = false
 	let b2 = await <Promise<ReturnType<typeof api.getBeatmaps> | false>>attempt("getBeatmaps: ", api.getBeatmaps([beatmap_id, 4089655]))
 	if (!isOk(b2, !b2 || (b2.length === 2 && validate(b2[0], "BeatmapExtended", generator)))) okay = false
 	let b3 = await <Promise<ReturnType<typeof api.getBeatmapDifficultyAttributes> | false>>attempt(
@@ -116,14 +117,14 @@ const testBeatmapStuff = async (): Promise<boolean> => {
 	let b5 = await <Promise<ReturnType<typeof api.getBeatmapUserScores> | false>>attempt(
 		"getBeatmapUserScores: ", api.getBeatmapUserScores({id: 203993}, {id: 7276846}, osu.Rulesets.fruits))
 	if (!isOk(b5, !b5 || (b5.length === 1 && validate(b5[0], "Score", score_gen)))) okay = false
-	let b6 = await <Promise<ReturnType<typeof api.getBeatmapset> | false>>attempt("getBeatmapset: ", api.getBeatmapset({id: 1971037}))
-	if (!isOk(b6, !b6 || (b6.submitted_date?.toISOString().substring(0, 10) === "2023-04-07", validate(b6, "BeatmapsetExtended", generator)))) okay = false
-	let b7 = await <Promise<ReturnType<typeof api.getBeatmapPack> | false>>attempt("getBeatmapPack: ", api.getBeatmapPack({tag: "P217"}))
+	let b6 = await <Promise<ReturnType<typeof api.getBeatmapset> | false>>attempt("getBeatmapset: ", api.getBeatmapset({id: 1971037}))
+	if (!isOk(b6, !b6 || (b6.submitted_date?.toISOString().substring(0, 10) === "2023-04-07", validate(b6, "BeatmapsetExtendedPlus", generator)))) okay = false
+	let b7 = await <Promise<ReturnType<typeof api.getBeatmapPack> | false>>attempt("getBeatmapPack: ", api.getBeatmapPack({tag: "P217"}))
 	if (!isOk(b7, !b7 || (b7.tag === "P217" && validate(b7, "BeatmapPack", generator)))) okay = false
-	let b8 = await <Promise<ReturnType<typeof api.getBeatmapPacks> | false>>attempt("getBeatmapPacks: ", api.getBeatmapPacks("tournament"))
+	let b8 = await <Promise<ReturnType<typeof api.getBeatmapPacks> | false>>attempt("getBeatmapPacks: ", api.getBeatmapPacks("tournament"))
 	if (!isOk(b8, !b8 || (b8.length >= 100 && validate(b8[0], "BeatmapPack", generator)))) okay = false
-	let b9 = await <Promise<ReturnType<typeof api.getBeatmapScores> | false>>attempt("getBeatmapScores: ", api.getBeatmapScores({id: 129891}))
-	if (!isOk(b9, !b9 || (b9[0].score >= 132408001))) okay = false
+	let b9 = await <Promise<ReturnType<typeof api.getBeatmapScores> | false>>attempt("getBeatmapScores: ", api.getBeatmapScores({id: 129891}))
+	if (!isOk(b9, !b9 || (b9[0].score >= 132408001 && validate(b9[0], "ScoreWithUser", score_gen)))) okay = false
 
 	return okay
 }
@@ -160,13 +161,13 @@ const testMultiplayerStuff = async (): Promise<boolean> => {
 	if (d1) { // can't bother getting and writing down the id of a playlist item
 		let d3 = await <Promise<ReturnType<typeof api.getPlaylistItemScores> | false>>attempt(
 			"getPlaylistItemScores (realtime): ", api.getPlaylistItemScores({id: d1.playlist[0].id, room_id: d1.id}))
-		!isOk(d3, !d3 || (d3.scores.length > 0 && validate(d3[0], "MultiplayerScore", generator))) ?
+		!isOk(d3, !d3 || (d3.scores.length > 0 && validate(d3.scores[0], "MultiplayerScores", generator))) ?
 			console.log("Bug not fixed yet...") : console.log("Bug fixed!!! :partying_face:")
 	}
 	if (d2) { // still can't bother getting and writing down the id of a playlist item
 		let d4 = await <Promise<ReturnType<typeof api.getPlaylistItemScores> | false>>attempt(
 			"getPlaylistItemScores (playlist): ", api.getPlaylistItemScores({id: d2.playlist[0].id, room_id: d2.id}))
-		if (!isOk(d4, !d4 || (d4.scores.length >= 50 && validate(d4[0], "MultiplayerScore", generator)))) okay = false
+		if (!isOk(d4, !d4 || (d4.scores.length >= 50 && validate(d4.scores[0], "MultiplayerScores", generator)))) okay = false
 	}
 	let d5 = await <Promise<ReturnType<typeof api.getMatch> | false>>attempt("getMatch: ", api.getMatch(62006076))
 	if (!isOk(d5, !d5 || (d5.match.name === "CWC2020: (Italy) vs (Indonesia)" && validate(d5, "Match", generator)))) okay = false
@@ -184,15 +185,15 @@ const testRankingStuff = async (): Promise<boolean> => {
 	let okay = true
 
 	let e1 = await <Promise<ReturnType<typeof api.getKudosuRanking> | false>>attempt("\ngetKudosuRanking: ", api.getKudosuRanking())
-	if (!isOk(e1, !e1 || (e1[0].kudosu!.total > 10000 && validate(e1[0], "User", generator)))) okay = false
+	if (!isOk(e1, !e1 || (e1[0].kudosu.total > 10000 && validate(e1[0], "UserWithKudosu", generator)))) okay = false
 	let e2 = await <Promise<ReturnType<typeof api.getRanking> | false>>attempt(
 		"getRanking: ", api.getRanking(osu.Rulesets.osu, "score", 1, "all", "FR"))
-  if (!isOk(e2, !e2 || (e2.ranking[0].level.current > 106 && validate(e2, "Rankings", generator)))) okay = false
+	if (!isOk(e2, !e2 || (e2.ranking[0].level.current > 106 && validate(e2, "Rankings", generator)))) okay = false
 	let e3 = await <Promise<ReturnType<typeof api.getCountryRanking> | false>>attempt("getCountryRanking: ", api.getCountryRanking(osu.Rulesets.osu))
-	if (!isOk(e3, !e3 || (e3.ranking[0].code === "US"))) okay = false
+	if (!isOk(e3, !e3 || (e3.ranking[0].code === "US" && validate(e3, "RankingsCountry", generator)))) okay = false
 	let e4 = await <Promise<ReturnType<typeof api.getSpotlightRanking> | false>>attempt(
 		"getSpotlightRanking: ", api.getSpotlightRanking(osu.Rulesets.taiko, {id: 48}))
-	if (!isOk(e4, !e4 || (e4.ranking[0].hit_accuracy === 97.85))) okay = false
+	if (!isOk(e4, !e4 || (e4.ranking[0].hit_accuracy === 97.85 && validate(e4, "RankingsSpotlight", generator)))) okay = false
 	let e5 = await <Promise<ReturnType<typeof api.getSpotlights> | false>>attempt("getSpotlights: ", api.getSpotlights())
 	if (!isOk(e5, !e5 || (e5.length >= 132 && validate(e5[0], "Spotlight", generator)))) okay = false
 

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -25,7 +25,7 @@ export interface User {
 	is_bot: boolean
 	is_deleted: boolean
 	is_online: boolean
-	is_supported: boolean
+	is_supporter: boolean
 	last_visit: Date | null
 	pm_friends_only: boolean
 	profile_colour: string | null
@@ -217,7 +217,10 @@ export interface UserStatistics {
 	 * Accuracy in the normal format, where 96.56% would be `96.56`
 	 */
 	hit_accuracy: number
-	is_ranked: number
+	/**
+	 * Hasn't went inactive in the rankings
+	 */
+	is_ranked: boolean
 	level: {
 		current: number
 		progress: number

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "devDependencies": {
     "@types/node": "^20.8.10",
     "@types/prompt-sync": "^4.2.2",
+    "ajv": "^8.12.0",
     "dotenv": "^16.3.1",
     "prompt-sync": "^4.2.0",
+    "ts-json-schema-generator": "^1.4.0",
     "typedoc": "^0.25.3",
     "typescript": "^5.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,15 @@
 # yarn lockfile v1
 
 
+"@types/json-schema@^7.0.12":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/node@^20.8.10":
-  version "20.9.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.0.tgz#bfcdc230583aeb891cf51e73cfdaacdd8deae298"
-  integrity sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==
+  version "20.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.1.tgz#9d578c610ce1e984adda087f685ace940954fe19"
+  integrity sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==
   dependencies:
     undici-types "~5.26.4"
 
@@ -13,6 +18,16 @@
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/prompt-sync/-/prompt-sync-4.2.3.tgz#b6a9fe88fc4b4cacb8ab59f87f2614d6e674e177"
   integrity sha512-Ox77gCSx0YyeakGt/qfOZUSFNSSi+sh3ABoGOiCwiO2KODx492BJnUm9oIXS+AHJtqp12iM4RduY6viTJ9bYwA==
+
+ajv@^8.12.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
 
 ansi-regex@^4.1.0:
   version "4.1.1"
@@ -36,6 +51,11 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
+commander@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+
 data-uri-to-buffer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
@@ -45,6 +65,11 @@ dotenv@^16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
@@ -61,6 +86,45 @@ formdata-polyfill@^4.0.10:
   dependencies:
     fetch-blob "^3.1.2"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
 jsonc-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
@@ -75,6 +139,13 @@ marked@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimatch@^9.0.3:
   version "9.0.3"
@@ -97,12 +168,39 @@ node-fetch@^3.3.2:
     fetch-blob "^3.1.4"
     formdata-polyfill "^4.0.10"
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
 prompt-sync@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/prompt-sync/-/prompt-sync-4.2.0.tgz#0198f73c5b70e3b03e4b9033a50540a7c9a1d7f4"
   integrity sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==
   dependencies:
     strip-ansi "^5.0.0"
+
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+safe-stable-stringify@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
 shiki@^0.14.1:
   version "0.14.5"
@@ -121,6 +219,19 @@ strip-ansi@^5.0.0:
   dependencies:
     ansi-regex "^4.1.0"
 
+ts-json-schema-generator@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-1.4.0.tgz#f341b36792c372d3d09245414a4f3a6efa2697f8"
+  integrity sha512-wm8vyihmGgYpxrqRshmYkWGNwEk+sf3xV2rUgxv8Ryeh7bSpMO7pZQOht+2rS002eDkFTxR7EwRPXVzrS0WJTg==
+  dependencies:
+    "@types/json-schema" "^7.0.12"
+    commander "^11.0.0"
+    glob "^8.0.3"
+    json5 "^2.2.3"
+    normalize-path "^3.0.0"
+    safe-stable-stringify "^2.4.3"
+    typescript "~5.2.2"
+
 typedoc@^0.25.3:
   version "0.25.3"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.3.tgz#53c6d668e1001b3d488e9a750fcdfb05433554c0"
@@ -131,7 +242,7 @@ typedoc@^0.25.3:
     minimatch "^9.0.3"
     shiki "^0.14.1"
 
-typescript@^5.2.2:
+typescript@^5.2.2, typescript@~5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
@@ -140,6 +251,13 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
 
 vscode-oniguruma@^1.7.0:
   version "1.7.0"
@@ -155,3 +273,8 @@ web-streams-polyfill@^3.0.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==


### PR DESCRIPTION
Using [ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator) and [Ajv JSON schema validator](https://github.com/ajv-validator/ajv)

My goal with this PR is for tests to automatically check if the objects they receive from the API match the interface that is supposed to describe them
For example, if I run `yarn test`, it would alert me if `api.getUser()` doesn't give an object that matches `UserExtended` because it's missing a certain property or because a property isn't the expected type
(this can be the fault of the API or the fault of the package, both are unstable)

I don't _think_ it's possible to check if an object has a property that the interface doesn't have? Kinda sucks if that's the case, but I really cannot complain

But I also want to test that by writing as little as possible, and spend as little time as possible for each test
As of the first commit, this goal hasn't quite been reached, there's definitely work to do

Note that making it so objects and interfaces do match is out of the scope of this PR, it can wait for both this and #26 to be merged