### PR TITLE
Add getComments() and getComment()

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Using the WebSocket namespace this package provides, it's relatively easy to sen
 - [x] `GET /chat/channels/{channel}` -> getChatChannel() (without `users` because `channel` would already have this property)
 
 ### Comments
-- [ ] `GET /comments`
-- [ ] `GET /comments/{comment}`
+- [x] `GET /comments` -> getComments()
+- [x] `GET /comments/{comment}` -> getComment()
 
 ### Events
 - [x] `GET /events` -> getEvents()

--- a/lib/comment.ts
+++ b/lib/comment.ts
@@ -26,11 +26,7 @@ export interface Comment {
 	message_html?: string
 }
 
-/**
- * @obtainableFrom
- * {@link API.getComments} /
- * {@link API.getComment}
-*/
+/** @obtainableFrom {@link API.getComment} */
 export interface CommentBundle {
 	comments: Comment[]
 	has_more: boolean
@@ -44,9 +40,7 @@ export interface CommentBundle {
 	cursor: {
 		created_at: Date
 		id: number
-	}
-	top_level_count: number
-	total: number
+	} | null
 	commentable_meta: {
 		id: number
 		title: string
@@ -67,4 +61,13 @@ export interface CommentBundle {
 	 * @remarks This DOES COUNT the one that is always there, see https://github.com/ppy/osu-web/issues/11077
 	 */
 	deleted_commentable_meta: number
+	
+}
+
+export namespace CommentBundle {
+	/** @obtainableFrom {@link API.getComments} */
+	export interface WithTotalToplevelcount extends CommentBundle {
+		total: number
+		top_level_count: number
+	}
 }

--- a/lib/comment.ts
+++ b/lib/comment.ts
@@ -1,0 +1,66 @@
+import { User } from "./user.js"
+
+export interface Comment {
+	id: number
+	parent_id: number | null
+	user_id: number
+	pinned: boolean
+	replies_count: number
+	votes_count: number
+	/** "build" means changelog, like pretty much everywhere in the API */
+	commentable_type: "beatmapset" | "build" | "news_post"
+	commentable_id: number
+	/** I think it's the name used by the person who made the comment before a migration to a new comment system in 2018 or before? */
+	legacy_name: string | null
+	created_at: Date
+	updated_at: Date
+	deleted_at: Date | null
+	edited_at: Date | null
+	edited_by_id: number | null
+	/** 
+	 * Yes comments may not have this property, yes this is stupid 
+	 * @privateRemarks Example is comment 3063736 from build 7463
+	 */
+	message?: string
+	/** Yes comments may not have this property, yes this is stupid */
+	message_html?: string
+}
+
+export interface CommentableMeta {
+	id: number
+	title: Exclude<string, "Deleted Item">
+	type: Comment["commentable_type"]
+	url: string
+	owner_id: number | null
+	owner_title: string | null
+	current_user_attributes: {
+		/** 
+		 * The string explains why the authorized user cannot post a new comment in this specific context, it's null if they can
+		 * @remarks If there is simply no authorized user, this'll be a string such as "Please sign in to proceed."
+		 */
+		can_new_comment_reason: string | null
+	}
+	deleted: false
+}
+
+export interface CommentBundle {
+	comments: Comment[]
+	has_more: boolean
+	has_more_id: number | null
+	included_comments: Comment[]
+	pinned_comments: Comment[]
+	user_votes: number[]
+	user_follow: boolean
+	users: User[]
+	sort: "new" | "old" | "top"
+	cursor: {
+		created_at: Date
+		id: number
+	}
+	top_level_count: number
+	total: number
+	commentable_meta: (CommentableMeta | {
+		title: "Deleted Item"
+		deleted: true
+	})[]
+}

--- a/lib/comment.ts
+++ b/lib/comment.ts
@@ -26,23 +26,11 @@ export interface Comment {
 	message_html?: string
 }
 
-export interface CommentableMeta {
-	id: number
-	title: Exclude<string, "Deleted Item">
-	type: Comment["commentable_type"]
-	url: string
-	owner_id: number | null
-	owner_title: string | null
-	current_user_attributes: {
-		/** 
-		 * The string explains why the authorized user cannot post a new comment in this specific context, it's null if they can
-		 * @remarks If there is simply no authorized user, this'll be a string such as "Please sign in to proceed."
-		 */
-		can_new_comment_reason: string | null
-	}
-	deleted: false
-}
-
+/**
+ * @obtainableFrom
+ * {@link API.getComments} /
+ * {@link API.getComment}
+*/
 export interface CommentBundle {
 	comments: Comment[]
 	has_more: boolean
@@ -59,8 +47,24 @@ export interface CommentBundle {
 	}
 	top_level_count: number
 	total: number
-	commentable_meta: (CommentableMeta | {
-		title: "Deleted Item"
-		deleted: true
-	})[]
+	commentable_meta: {
+		id: number
+		title: string
+		type: Comment["commentable_type"]
+		url: string
+		owner_id: number | null
+		owner_title: string | null
+		current_user_attributes: {
+			/** 
+			 * The string explains why the authorized user cannot post a new comment in this specific context, it's null if they can
+			 * @remarks If there is simply no authorized user, this'll be a string such as "Please sign in to proceed."
+			 */
+			can_new_comment_reason: string | null
+		}
+	}[]
+	/**
+	 * This is an original property of the package that lets you know how many `CommentableMeta`s that only consist of a `title` of "Deleted Item" got removed
+	 * @remarks This DOES COUNT the one that is always there, see https://github.com/ppy/osu-web/issues/11077
+	 */
+	deleted_commentable_meta: number
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1126,7 +1126,7 @@ export class API {
 	 * @param sort Should the comments be sorted by votes? Should they be from after a certain date? Maybe you can give a cursor?
 	 */
 	async getComments(from?: {type: Comment["commentable_type"], id: number}, parent?: Comment | {id: number | 0},
-	sort?: {type?: CommentBundle["sort"], after?: Comment | {id: number}, cursor?: CommentBundle["cursor"]}): Promise<CommentBundle> {
+	sort?: {type?: CommentBundle["sort"], after?: Comment | {id: number}, cursor?: CommentBundle["cursor"]}): Promise<CommentBundle.WithTotalToplevelcount> {
 		const after = sort?.after?.id ? String(sort.after.id) : undefined
 		const parent_id = parent?.id ? String(parent.id) : undefined
 
@@ -1146,6 +1146,11 @@ export class API {
 	 * @param comment The comment in question
 	 */
 	async getComment(comment: Comment | {id: number}): Promise<CommentBundle> {
-		return await this.request("get", `comments/${comment.id}`)
+		let bundle = await this.request("get", `comments/${comment.id}`)
+		const commentable_meta = bundle.commentable_meta.filter((c: any) => c.id)
+		bundle.deleted_commentable_meta = bundle.commentable_meta.length - commentable_meta.length
+		bundle.commentable_meta = commentable_meta
+		
+		return bundle
 	}
 }

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -257,7 +257,7 @@ const testHomeStuff = async (home_gen: tsj.SchemaGenerator, news_gen: tsj.Schema
 	return okay
 }
 
-const testMiscStuff = async (forum_gen: tsj.SchemaGenerator, event_gen: tsj.SchemaGenerator): Promise<boolean> => {
+const testMiscStuff = async (forum_gen: tsj.SchemaGenerator, event_gen: tsj.SchemaGenerator, comment_gen: tsj.SchemaGenerator): Promise<boolean> => {
 	let okay = true
 
 	let g1 = await <Promise<ReturnType<typeof api.getForumTopicAndPosts> | false>>attempt("\ngetForumTopicAndPosts: ", api.getForumTopicAndPosts({id: 1848236}, 2))
@@ -266,6 +266,14 @@ const testMiscStuff = async (forum_gen: tsj.SchemaGenerator, event_gen: tsj.Sche
 	if (!isOk(g2, !g2 || (g2.events.length === 50 && validate(g2.events, "Event.Any", event_gen)))) okay = false
 	let g3 = await <Promise<ReturnType<typeof api.getSeasonalBackgrounds> | false>>attempt("getSeasonalBackgrounds: ", api.getSeasonalBackgrounds())
 	if (!isOk(g3, !g3 || (g3.ends_at > new Date("2024-01-01") && g3.backgrounds.length > 0))) okay = false
+	let g4 = await <Promise<ReturnType<typeof api.getComments> | false>>attempt("getComments: ", api.getComments())
+	if (!isOk(g4, !g4 || validate(g4, "CommentBundle", comment_gen))) okay = false
+	let g5 = await <Promise<ReturnType<typeof api.getComments> | false>>attempt("getComments (beatmapset): ", api.getComments({type: "beatmapset", id: 1971037}))
+	if (!isOk(g5, !g5 || validate(g5, "CommentBundle", comment_gen))) okay = false
+	let g6 = await <Promise<ReturnType<typeof api.getComments> | false>>attempt("getComments (build): ", api.getComments({type: "build", id: 7463}))
+	if (!isOk(g6, !g6 || validate(g6, "CommentBundle", comment_gen))) okay = false
+	let g7 = await <Promise<ReturnType<typeof api.getComments> | false>>attempt("getComments (news_post): ", api.getComments({type: "news_post", id: 1451}))
+	if (!isOk(g7, !g7 || validate(g7, "CommentBundle", comment_gen))) okay = false
 
 	return okay
 }
@@ -287,7 +295,11 @@ const test = async (id: string, secret: string): Promise<void> => {
 		tsj.createGenerator({path: "lib/home.ts", additionalProperties: true}),
 		tsj.createGenerator({path: "lib/news.ts", additionalProperties: true})
 	)
-	const g = await testMiscStuff(tsj.createGenerator({path: "lib/forum.ts", additionalProperties: true}), event_gen)
+	const g = await testMiscStuff(
+		tsj.createGenerator({path: "lib/forum.ts", additionalProperties: true}),
+		event_gen,
+		tsj.createGenerator({path: "lib/comment.ts", additionalProperties: true})
+	)
 
 	const arr = [a,b,c,d,e,f,g]
 

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -274,6 +274,8 @@ const testMiscStuff = async (forum_gen: tsj.SchemaGenerator, event_gen: tsj.Sche
 	if (!isOk(g6, !g6 || validate(g6, "CommentBundle", comment_gen))) okay = false
 	let g7 = await <Promise<ReturnType<typeof api.getComments> | false>>attempt("getComments (news_post): ", api.getComments({type: "news_post", id: 1451}))
 	if (!isOk(g7, !g7 || validate(g7, "CommentBundle", comment_gen))) okay = false
+	let g8 = await <Promise<ReturnType<typeof api.getComment> | false>>attempt("getComment: ", api.getComment({id: 2418884}))
+	if (!isOk(g8, !g8 || (g8.users.find((u) => u.id === 8) && validate(g8, "CommentBundle", comment_gen)))) okay = false
 
 	return okay
 }


### PR DESCRIPTION
This PR adds full support for the two routes related to comments that aren't locked behind lazer

[In an effort to stay as close to the original response of the API while making things more convenient for the package users,](https://www.wordnik.com/words/fall%20between%20two%20stools) CommentableMetas that lack ids and that are therefore "Deleted Items" are filtered out, and a property called `deleted_commentable_meta` exists to let users know that the filtering happened

Furthermore, one of these routes doesn't support `cursor_string`, instead using the "soon to be replaced" `cursor`, and it turns out the package had no support for these; Prior to this PR, it didn't support objects in GET requests (or even Dates)
So this PR tweaks quite a bit the code that handles GET requests to support more kinds of requests, although this theoretically should only be ever useful for cursors