### PR TITLE
Add getBeatmapsetDiscussions(), getBeatmapsetDiscussionVotes(), and getBeatmapsetDiscussionPosts()

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Using the WebSocket namespace this package provides, it's relatively easy to sen
 - [x] `POST /beatmaps/{beatmap}/attributes` -> getBeatmapDifficultyAttributes()
 
 ### Beatmapset Discussions
-- [ ] `GET /beatmapsets/discussions/posts`
-- [ ] `GET /beatmapsets/discussions/votes`
+- [x] `GET /beatmapsets/discussions/posts` -> getBeatmapsetDiscussionPosts()
+- [x] `GET /beatmapsets/discussions/votes` -> getBeatmapsetDiscussionVotes()
 - [x] `GET /beatmapsets/discussions` -> getBeatmapsetDiscussions()
 
 ### Beatmapsets

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Using the WebSocket namespace this package provides, it's relatively easy to sen
 ### Beatmapset Discussions
 - [ ] `GET /beatmapsets/discussions/posts`
 - [ ] `GET /beatmapsets/discussions/votes`
-- [ ] `GET /beatmapsets/discussions`
+- [x] `GET /beatmapsets/discussions` -> getBeatmapsetDiscussions()
 
 ### Beatmapsets
 - [ ] `GET /beatmapsets/search`

--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -186,7 +186,14 @@ export interface Beatmapset {
 }
 
 export namespace Beatmapset {
-	export interface Extended extends Beatmapset {
+	export interface WithHype extends Beatmapset {
+		hype: {
+			current: number
+			required: number
+		} | null
+	}
+
+	export interface Extended extends WithHype {
 		availability: {
 			/** So it's `false` if you can download it */
 			download_disabled: boolean
@@ -197,10 +204,6 @@ export namespace Beatmapset {
 		creator: string
 		deleted_at: string | null
 		discussion_locked: boolean
-		hype: {
-			current: number
-			required: number
-		} | null
 		is_scoreable: boolean
 		last_updated: Date
 		legacy_thread_url: string
@@ -262,7 +265,7 @@ export namespace Beatmapset {
 		beatmap_id: number | null
 		user_id: number
 		deleted_by_id: number | null
-		message_type: "mapper_note" | "hype" | "praise" | "suggestion" | "problem" | "review"
+		message_type: "suggestion" | "problem" | "mapper_note" | "praise" | "hype" | "review"
 		parent_id: number | null
 		timestamp: number | null
 		resolved: boolean
@@ -273,10 +276,13 @@ export namespace Beatmapset {
 		deleted_at: Date | null
 		last_post_at: Date
 		kudosu_denied: boolean
-		starting_post: Discussion.Post
 	}
 
 	export namespace Discussion {
+		export interface WithStartingpost extends Discussion {
+			starting_post: Discussion.Post
+		}
+
 		export interface Post {
 			beatmapset_discussion_id: number
 			created_at: Date

--- a/lib/beatmap.ts
+++ b/lib/beatmap.ts
@@ -171,7 +171,7 @@ export interface Beatmapset {
 	nsfw: boolean
 	offset: number
 	play_count: number
-	/** A string like that, where id is the `id` of the beatmapset: `//b.ppy.sh/preview/58951.mp3` */
+	/** A string like that where id is the `id` of the beatmapset: `//b.ppy.sh/preview/58951.mp3` */
 	preview_url: string
 	source: string
 	spotlight: boolean
@@ -253,6 +253,50 @@ export namespace Beatmapset {
 			user: User
 			/** Only exists if authorized user */
 			has_favourited?: boolean
+		}
+	}
+
+	export interface Discussion {
+		id: number
+		beatmapset_id: number
+		beatmap_id: number | null
+		user_id: number
+		deleted_by_id: number | null
+		message_type: "mapper_note" | "hype" | "praise" | "suggestion" | "problem" | "review"
+		parent_id: number | null
+		timestamp: number | null
+		resolved: boolean
+		can_be_resolved: boolean
+		can_grant_kudosu: boolean
+		created_at: Date
+		updated_at: Date
+		deleted_at: Date | null
+		last_post_at: Date
+		kudosu_denied: boolean
+		starting_post: Discussion.Post
+	}
+
+	export namespace Discussion {
+		export interface Post {
+			beatmapset_discussion_id: number
+			created_at: Date
+			deleted_at: Date | null
+			deleted_by_id: number | null
+			id: number
+			last_editor_id: number | null
+			message: string
+			system: boolean
+			updated_at: Date
+			user_id: number
+		}
+
+		export interface Vote {
+			beatmapset_discussion_id: number
+			created_at: Date
+			id: number
+			score: number
+			updated_at: Date
+			user_id: number
 		}
 	}
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -626,7 +626,7 @@ export class API {
 	}
 
 	/**
-	 * Get complex data about the discussion page of any beatmap that you want!
+	 * Get complex data about the discussion page of any beatmapet that you want!
 	 * @param from From where/who are the discussions coming from? Maybe only qualified sets?
 	 * @param filter Should those discussions only be unresolved problems, for example?
 	 * @param cursor_stuff How many results maximum to get, which page of those results, a cursor_string if you have that...
@@ -636,21 +636,46 @@ export class API {
 	 * @privateRemarks I don't allow setting `beatmap_id` because my testing has led me to believe it does nothing (and is therefore misleading)
 	 */
 	async getBeatmapsetDiscussions(from?: {beatmapset?: Beatmapset | {id: number}, user?: User | {id: number},
-	status?: "all" | "ranked" | "qualified" | "disqualified" | "never_qualified"}, filter?:{types?: Beatmapset.Discussion["message_type"][],
+	status?: "all" | "ranked" | "qualified" | "disqualified" | "never_qualified"}, filter?: {types?: Beatmapset.Discussion["message_type"][],
 	only_unresolved?: boolean}, cursor_stuff?: {page?: number, limit?: number, cursor_string?: string}, sort: "id_desc" | "id_asc" = "id_desc"):
-	Promise<{beatmaps: Beatmap.Extended[], beatmapsets: Beatmapset.Extended[], discussions: Beatmapset.Discussion[]
-	included_discussions: Beatmapset.Discussion[], reviews_config: {max_blocks: number}, users: User.WithGroups[], cursor_string: string}> {
+	Promise<{beatmaps: Beatmap.Extended[], beatmapsets: Beatmapset.Extended[], discussions: Beatmapset.Discussion.WithStartingpost[]
+	included_discussions: Beatmapset.Discussion.WithStartingpost[], reviews_config: {max_blocks: number}, users: User.WithGroups[], cursor_string: string}> {
 		return await this.request("get", "beatmapsets/discussions", {beatmapset_id: from?.beatmapset?.id, beatmapset_status: from?.status,
 		limit: cursor_stuff?.limit, message_types: filter?.types, only_unresolved: filter?.only_unresolved, page: cursor_stuff?.page, sort,
 		user: from?.user?.id, cursor_string: cursor_stuff?.cursor_string})
 	}
 
-	private async getBeatmapsetDiscussionPosts() {
-		return await this.request("get", "beatmapsets/discussions/posts")
+	/**
+	 * Get complex data about the posts of a beatmapset's discussion or of a user!
+	 * @param from From where/who are the posts coming from? A specific discussion, a specific user?
+	 * @param types What kind of posts?
+	 * @param cursor_stuff How many results maximum to get, which page of those results, a cursor_string if you have that...
+	 * @param sort (defaults to "id_desc") "id_asc" to have the oldest recent post first, "id_desc" to have the newest instead
+	 * @returns Relevant posts and info about them
+	 * @remarks (2024-03-11) For months now, the API's documentation says the response is likely to change, so beware
+	 */
+	async getBeatmapsetDiscussionPosts(from?: {discussion?: Beatmapset.Discussion | {id: number}, user?: User | {id: number}},
+	types?: ("first" | "reply" | "system")[], cursor_stuff?: {page?: number, limit?: number, cursor_string?: string}, sort: "id_desc" | "id_asc" = "id_desc"):
+	Promise<{beatmapsets: Beatmapset.WithHype[], posts: Beatmapset.Discussion.Post[], users: User[], cursor_string: string}> {
+		return await this.request("get", "beatmapsets/discussions/posts", {beatmapset_discussion_id: from?.discussion?.id, limit: cursor_stuff?.limit,
+		page: cursor_stuff?.page, sort, types, user: from?.user?.id, cursor_string: cursor_stuff?.cursor_string})
 	}
 
-	private async getBeatmapsetDiscussionVotes() {
-		return await this.request("get", "beatmapsets/discussions/votes")
+	/**
+	 * Get complex data about the votes of a beatmapset's discussions or/and received/given by a specific user!
+	 * @param from The discussion with the votes, the user who voted, the user who's gotten the votes...
+	 * @param score An upvote (1) or a downvote (-1)
+	 * @param cursor_stuff How many results maximum to get, which page of those results, a cursor_string if you have that...
+	 * @param sort (defaults to "id_desc") "id_asc" to have the oldest recent vote first, "id_desc" to have the newest instead
+	 * @returns Relevant votes and info about them
+	 * @remarks (2024-03-11) For months now, the API's documentation says the response is likely to change, so beware
+	 */
+	async getBeatmapsetDiscussionVotes(from?: {discussion?: Beatmapset.Discussion | {id: number}, vote_giver?: User | {id: number},
+	vote_receiver?: User | {id: number}}, score?: 1 | -1, cursor_stuff?: {page?: number, limit?: number, cursor_string?: string},
+	sort: "id_desc" | "id_asc" = "id_desc"): Promise<{votes: Beatmapset.Discussion.Vote[], discussions: Beatmapset.Discussion[], users: User.WithGroups[],
+	cursor_string: string}> {
+		return await this.request("get", "beatmapsets/discussions/votes", {beatmapset_discussion_id: from?.discussion?.id, limit: cursor_stuff?.limit,
+		page: cursor_stuff?.page, receiver: from?.vote_receiver?.id, score, sort, user: from?.vote_giver?.id, cursor_string: cursor_stuff?.cursor_string})
 	}
 
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -625,6 +625,34 @@ export class API {
 		return response.beatmap_packs
 	}
 
+	/**
+	 * Get complex data about the discussion page of any beatmap that you want!
+	 * @param from From where/who are the discussions coming from? Maybe only qualified sets?
+	 * @param filter Should those discussions only be unresolved problems, for example?
+	 * @param cursor_stuff How many results maximum to get, which page of those results, a cursor_string if you have that...
+	 * @param sort (defaults to "id_desc") "id_asc" to have the oldest recent discussion first, "id_desc" to have the newest instead
+	 * @returns Relevant discussions and info about them
+	 * @remarks (2024-03-11) For months now, the API's documentation says the response is likely to change, so beware
+	 * @privateRemarks I don't allow setting `beatmap_id` because my testing has led me to believe it does nothing (and is therefore misleading)
+	 */
+	async getBeatmapsetDiscussions(from?: {beatmapset?: Beatmapset | {id: number}, user?: User | {id: number},
+	status?: "all" | "ranked" | "qualified" | "disqualified" | "never_qualified"}, filter?:{types?: Beatmapset.Discussion["message_type"][],
+	only_unresolved?: boolean}, cursor_stuff?: {page?: number, limit?: number, cursor_string?: string}, sort: "id_desc" | "id_asc" = "id_desc"):
+	Promise<{beatmaps: Beatmap.Extended[], beatmapsets: Beatmapset.Extended[], discussions: Beatmapset.Discussion[]
+	included_discussions: Beatmapset.Discussion[], reviews_config: {max_blocks: number}, users: User.WithGroups[], cursor_string: string}> {
+		return await this.request("get", "beatmapsets/discussions", {beatmapset_id: from?.beatmapset?.id, beatmapset_status: from?.status,
+		limit: cursor_stuff?.limit, message_types: filter?.types, only_unresolved: filter?.only_unresolved, page: cursor_stuff?.page, sort,
+		user: from?.user?.id, cursor_string: cursor_stuff?.cursor_string})
+	}
+
+	private async getBeatmapsetDiscussionPosts() {
+		return await this.request("get", "beatmapsets/discussions/posts")
+	}
+
+	private async getBeatmapsetDiscussionVotes() {
+		return await this.request("get", "beatmapsets/discussions/votes")
+	}
+
 
 	// CHANGELOG STUFF
 

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -121,7 +121,7 @@ const testUserStuff = async (user_gen: tsj.SchemaGenerator, score_gen: tsj.Schem
 /**
  * Check if getBeatmap() and similar work fine 
  */
-const testBeatmapStuff = async (beat_gen: tsj.SchemaGenerator, score_gen: tsj.SchemaGenerator): Promise<boolean> => {
+const testBeatmapStuff = async (beat_gen: tsj.SchemaGenerator, score_gen: tsj.SchemaGenerator, user_gen: tsj.SchemaGenerator): Promise<boolean> => {
 	let okay = true
 	const beatmap_id = 388463
 	const long_str = "Beatmap.Extended.WithFailtimesBeatmapsetextended"
@@ -164,6 +164,12 @@ const testBeatmapStuff = async (beat_gen: tsj.SchemaGenerator, score_gen: tsj.Sc
 	if (!isOk(b13, !b13 || (b13[0].score >= 132408001 && validate(b13, "Score.WithUser", score_gen)))) okay = false
 	let b14 = await <Promise<ReturnType<typeof api.getBeatmapSoloScores> | false>>attempt("getBeatmapSoloScores: ", api.getBeatmapSoloScores({id: 129891}))
 	if (!isOk(b14, !b14 || (b14[0].total_score >= 1073232 && validate(b14, "Score.Solo", score_gen)))) okay = false
+
+	let b15 = await <Promise<ReturnType<typeof api.getBeatmapsetDiscussions> | false>>attempt(
+		"getBeatmapsetDiscussions: ", api.getBeatmapsetDiscussions({beatmapset: {id: 2119925}}))
+	if (!isOk(b15, !b15 || (validate(b15.beatmaps, "Beatmap.Extended", beat_gen) && validate(b15.beatmapsets, "Beatmapset.Extended", beat_gen) &&
+	validate(b15.users, "User.WithGroups", user_gen) && validate(b15.discussions, "Beatmapset.Discussion", beat_gen) &&
+	validate(b15.included_discussions, "Beatmapset.Discussion", beat_gen)))) okay = false
 
 	return okay
 }
@@ -279,7 +285,7 @@ const test = async (id: string, secret: string): Promise<void> => {
 	const event_gen = tsj.createGenerator({path: "lib/event.ts", additionalProperties: true})
 
 	const a = await testUserStuff(user_gen, score_gen, beat_gen, event_gen)
-	const b = await testBeatmapStuff(beat_gen, score_gen)
+	const b = await testBeatmapStuff(beat_gen, score_gen, user_gen)
 	const c = await testChangelogStuff(tsj.createGenerator({path: "lib/changelog.ts", additionalProperties: true}))
 	const d = await testMultiplayerStuff(tsj.createGenerator({path: "lib/multiplayer.ts", additionalProperties: true}))
 	const e = await testRankingStuff(tsj.createGenerator({path: "lib/ranking.ts", additionalProperties: true}))

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -168,8 +168,16 @@ const testBeatmapStuff = async (beat_gen: tsj.SchemaGenerator, score_gen: tsj.Sc
 	let b15 = await <Promise<ReturnType<typeof api.getBeatmapsetDiscussions> | false>>attempt(
 		"getBeatmapsetDiscussions: ", api.getBeatmapsetDiscussions({beatmapset: {id: 2119925}}))
 	if (!isOk(b15, !b15 || (validate(b15.beatmaps, "Beatmap.Extended", beat_gen) && validate(b15.beatmapsets, "Beatmapset.Extended", beat_gen) &&
-	validate(b15.users, "User.WithGroups", user_gen) && validate(b15.discussions, "Beatmapset.Discussion", beat_gen) &&
-	validate(b15.included_discussions, "Beatmapset.Discussion", beat_gen)))) okay = false
+	validate(b15.users, "User.WithGroups", user_gen) && validate(b15.discussions, "Beatmapset.Discussion.WithStartingpost", beat_gen) &&
+	validate(b15.included_discussions, "Beatmapset.Discussion.WithStartingpost", beat_gen)))) okay = false
+	let b16 = await <Promise<ReturnType<typeof api.getBeatmapsetDiscussionPosts> | false>>attempt(
+		"getBeatmapsetDiscussions: ", api.getBeatmapsetDiscussionPosts({discussion: {id: 4143461}}))
+	if (!isOk(b16, !b16 || (validate(b16.beatmapsets, "Beatmapset.WithHype", beat_gen) && validate(b16.users, "User", user_gen) &&
+	validate(b16.posts, "Beatmapset.Discussion.Post", beat_gen)))) okay = false
+	let b17 = await <Promise<ReturnType<typeof api.getBeatmapsetDiscussionVotes> | false>>attempt(
+		"getBeatmapsetDiscussionVotes: ", api.getBeatmapsetDiscussionVotes({vote_receiver: {id: 7276846}}))
+	if (!isOk(b17, !b17 || (validate(b17.votes, "Beatmapset.Discussion.Vote", beat_gen) && validate(b17.discussions, "Beatmapset.Discussion", beat_gen) &&
+	validate(b17.users, "User.WithGroups", user_gen)))) okay = false
 
 	return okay
 }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -38,7 +38,7 @@ export namespace User {
 		}
 	}
 
-	interface WithCountryCoverGroups extends WithCountryCover {
+	export interface WithGroups {
 		groups: {
 			colour: string | null
 			has_listing: boolean
@@ -53,7 +53,7 @@ export namespace User {
 	}
 
 	/** @obtainableFrom {@link API.getUsers} */
-	export interface WithCountryCoverGroupsStatisticsrulesets extends WithCountryCoverGroups {
+	export interface WithCountryCoverGroupsStatisticsrulesets extends WithCountryCover, WithGroups {
 		statistics_rulesets: {
 			osu?: Statistics
 			taiko?: Statistics
@@ -63,13 +63,13 @@ export namespace User {
 	}
 
 	/** @obtainableFrom {@link API.getFriends} */
-	export interface WithCountryCoverGroupsStatisticsSupport extends WithCountryCoverGroups {
+	export interface WithCountryCoverGroupsStatisticsSupport extends WithCountryCover, WithGroups {
 		statistics: Statistics
 		support_level: number
 	}
 
 	/** @obtainableFrom {@link API.getUser} */
-	export interface Extended extends User.WithCountryCoverGroupsStatisticsSupport, User.WithKudosu {
+	export interface Extended extends WithCountryCoverGroupsStatisticsSupport, WithKudosu {
 		cover_url: string
 		discord: string | null
 		has_supported: boolean
@@ -111,17 +111,6 @@ export namespace User {
 		favourite_beatmapset_count: number
 		follower_count: number
 		graveyard_beatmapset_count: number
-		groups: {
-			colour: string | null
-			has_listing: boolean
-			has_playmodes: boolean
-			id: number
-			identifier: string
-			is_probationary: boolean
-			name: string
-			playmodes: string[] | null
-			short_name: string
-		}[]
 		guest_beatmapset_count: number
 		loved_beatmapset_count: number
 		mapping_follower_count: number


### PR DESCRIPTION
I was initially reluctant to add them because the response of the endpoints these functions utilize was "likely to change soon"
However, it's been months now and nothing has changed, so I'm adding these functions and will adjust them if anything changes on the side of the API

This PR doesn't change much pre-existing code, it only:
- Creates `Beatmapset.WithHype`, which `Beatmapset.Extended` now extends instead of extending `Beatmapset`
- Splits `User.WithCountryCoverGroups` into two (`User.WithGroups` & `User.WithCountryCover`)
- Requires the stuff that tests Beatmaps to use `user_gen`, the user schema generator