### PR TITLE
Add `API.withSettings()` and `ChildAPI` to allow users giving `AbortSignal`s

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -259,8 +259,18 @@ export class API {
 		await new_api.getAndSetToken({client_id: client.id, client_secret: client.secret, grant_type: "client_credentials", scope: "public"}, new_api)
 	}
 
-	public with(overrides: ChildAPI["overrides"]): ChildAPI {
-		return new ChildAPI(this, overrides)
+	/**
+	 * You can use this to specify additional settings for the method you're going to call, such as `headers`, an `AbortSignal`, and more advanced things!
+	 * @example
+	 * ```ts
+	 * const controller = new AbortController() // this controller can be used to abort any request that uses its signal!
+	 * const user = await api.withSettings({signal: controller.signal}).getUser(7276846)
+	 * ```
+	 * @param additional_fetch_settings You may get more info at https://www.npmjs.com/package/node-fetch#fetch-options
+	 * @returns A special version of the `API` that changes how requests are done
+	 */
+	public withSettings(additional_fetch_settings: ChildAPI["additional_fetch_settings"]): ChildAPI {
+		return new ChildAPI(this, additional_fetch_settings)
 	}
 
 	/** 
@@ -407,11 +417,13 @@ export class API {
 	 * @param method The type of request, each endpoint uses a specific one (if it uses multiple, the intent and parameters become different)
 	 * @param endpoint What comes in the URL after `api/`
 	 * @param parameters The things to specify in the request, such as the beatmap_id when looking for a beatmap
+	 * @param settings Additional settings **to add** to the current settings of the `fetch()` request
 	 * @param info Context given by a prior request
 	 * @returns A Promise with the API's response
 	 */
-	public async request(method: "get" | "post" | "put" | "delete", endpoint: string, parameters: {[k: string]: any} = {}, overrides?: ChildAPI["overrides"],
-	info: {number_try: number, just_refreshed: boolean} = {number_try: 1, just_refreshed: false}): Promise<any> {
+	public async request(method: "get" | "post" | "put" | "delete", endpoint: string, parameters: {[k: string]: any} = {},
+	settings?: ChildAPI["additional_fetch_settings"],info: {number_try: number, just_refreshed: boolean} = {number_try: 1, just_refreshed: false}):
+	Promise<any> {
 		let to_retry = false
 		let error_object: Error | undefined
 		let error_code: number | undefined
@@ -423,9 +435,9 @@ export class API {
 			if (this.retry.on_timeout) {
 				to_retry = true
 			}
-			timeout_controller.abort()
+			timeout_controller.abort(`The request wasn't made in time (took more than ${this.timeout} seconds)`)
 		}, this.timeout * 1000) : false
-		const signal = overrides?.signal ? anySignal([timeout_signal, overrides.signal as AbortSignal]) : timeout_signal
+		const signal = settings?.signal ? anySignal([timeout_signal, settings.signal as AbortSignal]) : timeout_signal
 
 		// For GET requests specifically, requests need to be shaped in very particular ways
 		if (parameters !== undefined && method === "get") {
@@ -440,15 +452,16 @@ export class API {
 
 		const response = await fetch(url, {
 			method,
+			...settings, // has priority over what's above, but not over what's lower
 			headers: {
 				"Accept": "application/json",
 				"Accept-Encoding": "gzip",
 				"Content-Type": "application/json",
 				"User-Agent": "osu-api-v2-js (https://github.com/TTTaevas/osu-api-v2-js)",
-				"Authorization": `${this.token_type} ${this.access_token}`
+				"Authorization": `${this.token_type} ${this.access_token}`,
+				...settings?.headers // written that way, custom headers with (for example) only a user-agent would only overwrite the default user-agent
 			},
 			body: method !== "get" ? JSON.stringify(parameters) : undefined, // parameters are here if request is NOT GET
-			...overrides, // has priority over what's above, but not over what's lower
 			signal
 		})
 		.catch((error: AbortError | FetchError) => {
@@ -501,7 +514,7 @@ export class API {
 			if (to_retry === true && this.retry.disabled === false && info.number_try < this.retry.maximum_amount) {
 				this.log(true, `Will request again in ${this.retry.delay} seconds...`, `(Try #${info.number_try})`)
 				await new Promise(res => setTimeout(res, this.retry.delay))
-				return await this.request(method, endpoint, parameters, overrides, {number_try: info.number_try + 1, just_refreshed: info.just_refreshed})
+				return await this.request(method, endpoint, parameters, settings, {number_try: info.number_try + 1, just_refreshed: info.just_refreshed})
 			}
 
 			throw new APIError(error_string, `${this.server}/api/v2`, endpoint, parameters, error_code, error_object)
@@ -784,14 +797,16 @@ export class API {
 }
 
 /**
- * Created with {@link API.with}
+ * Created with {@link API.withSettings}, this special version of the {@link API} specifies additional settings to every request!
+ * @remarks This **is not** to be used for any purpose other than calling methods; The original {@link ChildAPI.original} handles tokens & configuration
  */
 export class ChildAPI extends API {
-	/** The {@link API} where {@link API.with} was used; this `ChildAPI` gets everything from it! */
+	/** The {@link API} where {@link API.withSettings} was used; this `ChildAPI` gets everything from it! */
 	original: API
-	overrides: RequestInit
+	/** The additional settings that are used for every request made by this object */
+	additional_fetch_settings: Omit<RequestInit, "body">
 	request = async (...args: Parameters<API["request"]>) => {
-		args[3] ??= this.overrides
+		args[3] ??= this.additional_fetch_settings // args[3] is `settings` **for now**
 		return await this.original.request(...args)
 	}
 
@@ -832,12 +847,12 @@ export class ChildAPI extends API {
 	/** @hidden @deprecated use API equivalent */
 	revokeToken = async () => {return await this.original.revokeToken()}
 	/** @hidden @deprecated use API equivalent */
-	with = (...args: Parameters<API["with"]>) => {return this.original.with(...args)}
+	withSettings = (...args: Parameters<API["withSettings"]>) => {return this.original.withSettings(...args)}
 	
-	constructor(original: ChildAPI["original"], overrides: ChildAPI["overrides"]) {
+	constructor(original: ChildAPI["original"], additional_fetch_settings: ChildAPI["additional_fetch_settings"]) {
 		super({})
 
 		this.original = original
-		this.overrides = overrides
+		this.additional_fetch_settings = additional_fetch_settings
 	}
 }

--- a/lib/misc.ts
+++ b/lib/misc.ts
@@ -1,5 +1,8 @@
 import { API } from "./index.js"
 
+
+// EXPORTED FOR PACKAGE USERS
+
 /**
  * Scopes determine what the API instance can do as a user!
  * https://osu.ppy.sh/docs/index.html#scopes
@@ -45,6 +48,119 @@ export namespace Spotlight {
 		const response = await this.request("get", "spotlights")
 		return response.spotlights // It's the only property
 	}
+}
+
+
+// PRIVATE TO PACKAGE USERS
+
+/**
+ * When using `fetch()` for a GET request, you can't just give the parameters the same way you'd give them for a POST request!
+ * @param parameters The parameters as they'd be for a POST request (prior to using `JSON.stringify`)
+ * @returns Parameters adapted for a GET request
+ */
+export function adaptParametersForGETRequests(parameters: {[k: string]: any}): {[k: string]: any} {
+	// If a parameter is an empty string or is undefined, remove it
+	for (let i = 0; i < Object.entries(parameters).length; i++) {
+		if (!String(Object.values(parameters)[i]).length || Object.values(parameters)[i] === undefined) {
+			delete parameters[Object.keys(parameters)[i]]
+			i--
+		}
+	}
+
+	// If a parameter is an Array, add "[]" to its name, so the server understands the request properly
+	for (let i = 0; i < Object.entries(parameters).length; i++) {	
+		if (Array.isArray(Object.values(parameters)[i]) && !Object.keys(parameters)[i].includes("[]")) {
+			parameters[`${Object.keys(parameters)[i]}[]`] = Object.values(parameters)[i]
+			delete parameters[Object.keys(parameters)[i]]
+			i--
+		}
+	}
+
+	// If a parameter is an object, add its properties in "[]" such as "cursor[id]=5&cursor[score]=36.234"
+	let parameters_to_add: {[k: string]: any} = {}
+	for (let i = 0; i < Object.entries(parameters).length; i++) {
+		const value = Object.values(parameters)[i]
+		if (typeof value === "object" && !Array.isArray(value) && value !== null) { 
+			const main_name = Object.keys(parameters)[i]
+			for (let e = 0; e < Object.entries(value).length; e++) {
+				parameters_to_add[`${main_name}[${Object.keys(value)[e]}]`] = Object.values(value)[e]
+			}
+			delete parameters[Object.keys(parameters)[i]]
+			i--
+		}
+	}
+	for (let i = 0; i < Object.entries(parameters_to_add).length; i++) {
+		parameters[Object.keys(parameters_to_add)[i]] = Object.values(parameters_to_add)[i]
+	}
+
+	// If a parameter is a date, make it a string
+	for (let i = 0; i < Object.entries(parameters).length; i++) {
+		if (Object.values(parameters)[i] instanceof Date) {
+			parameters[Object.keys(parameters)[i]] = (Object.values(parameters)[i] as Date).toISOString()
+		}
+	}
+
+	return parameters
+}
+
+/**
+ * Some stuff doesn't have the right type to begin with, such as dates, which are being returned as strings, this fixes that
+ * @param x Anything, but should be a string, an array that contains a string, or an object which has a string
+ * @returns x, but with it (or what it contains) now having the correct type
+ */
+export function correctType(x: any): any {
+	const bannedProperties = [
+		"name", "artist", "title", "location", "interests", "occupation", "twitter",
+		"discord", "version", "author", "raw", "bbcode", "title", "message", "creator", "source"
+	]
+
+	if (typeof x === "boolean") {
+		return x
+	} else if (/^[+-[0-9][0-9]+-[0-9]{2}-[0-9]{2}($|[ T].*)/.test(x)) {
+		if (/[0-9]{2}:[0-9]{2}:[0-9]{2}$/.test(x)) x += "Z"
+		if (/[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}$/.test(x)) x = x.substring(0, x.indexOf("+")) + "Z"
+		return new Date(x)
+	} else if (Array.isArray(x)) {
+		return x.map((e) => correctType(e))
+	} else if (!isNaN(x) && x !== "") {
+		return x === null ? null : Number(x)
+	} else if (typeof x === "object" && x !== null) {
+		const k = Object.keys(x)
+		const v = Object.values(x)
+		for (let i = 0; i < k.length; i++) {
+			if (typeof v[i] === "string" && bannedProperties.some((p) => k[i].includes(p))) continue // don't turn names made of numbers into integers
+			x[k[i]] = correctType(v[i])
+		}
+	}
+	return x
+}
+
+/**
+ * This is an alternative to `AbortSignal.any` that is friendly to older versions of Node.js, it was provided by the kind https://github.com/baileyherbert
+ * @param signals The multiple signals you'd want `fetch()` to take
+ * @returns A signal that's aborted when any of the `signals` is aborted
+ */
+export function anySignal(signals: AbortSignal[]) {
+	const controller = new AbortController()
+	const unsubscribe: (() => void)[] = []
+
+	function onAbort(signal: AbortSignal) {
+		controller.abort(signal.reason)
+		unsubscribe.forEach((f) => f())
+	}
+
+	for (const signal of signals) {
+		if (signal.aborted) {
+			onAbort(signal)
+			break
+		}
+
+		const handler = onAbort.bind(undefined, signal)
+		signal.addEventListener("abort", handler)
+		unsubscribe.push(() => signal.removeEventListener("abort", handler))
+	}
+
+	return controller.signal
 }
 
 /**

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -341,36 +341,50 @@ const testOther = async (): Promise<boolean> => {
 const test = async (id: string, secret: string): Promise<void> => {
 	api = await osu.API.createAsync({id: Number(id), secret}, undefined, "all") //"http://127.0.0.1:8080")
 
-	const tests = [
-		testBeatmapPack,
-		testBeatmap,
-		testBeatmapsetDiscussion,
-		testBeatmapset,
-		testChangelog,
-		testComment,
-		testEvent,
-		testForum,
-		testHome,
-		testMultiplayer,
-		testNews,
-		testRanking,
-		testUser,
-		testWiki,
-		testOther,
-	]
+	const controller = new AbortController()
+	const new_api = api.with({signal: controller.signal})
 
-	const results: {test_name: string, passed: boolean}[] = []
-	for (let i = 0; i < tests.length; i++) {
-		results.push({test_name: tests[i].name, passed: await tests[i]()})
-	}
-	console.log("\n", ...results.map((r) => `${r.test_name}: ${r.passed ? "✔️" : "❌"}\n`))
-	await api.revokeToken()
+	setTimeout(() => controller.abort(), 300)
 
-	if (!results.find((r) => !r.passed)) {
-		console.log("✔️ Looks like the test went well!")
-	} else {
-		throw new Error("❌ Something in the test went wrong...")
-	}
+	await Promise.all([
+		attempt(api.getUser, 7276846),
+		attempt(api.getUser, 7276845),
+		attempt(new_api.getUser, 7276846),
+		attempt(new_api.getUser, 7276845),
+	])
+
+	api.revokeToken()
+
+	// const tests = [
+	// 	testBeatmapPack,
+	// 	testBeatmap,
+	// 	testBeatmapsetDiscussion,
+	// 	testBeatmapset,
+	// 	testChangelog,
+	// 	testComment,
+	// 	testEvent,
+	// 	testForum,
+	// 	testHome,
+	// 	testMultiplayer,
+	// 	testNews,
+	// 	testRanking,
+	// 	testUser,
+	// 	testWiki,
+	// 	testOther,
+	// ]
+
+	// const results: {test_name: string, passed: boolean}[] = []
+	// for (let i = 0; i < tests.length; i++) {
+	// 	results.push({test_name: tests[i].name, passed: await tests[i]()})
+	// }
+	// console.log("\n", ...results.map((r) => `${r.test_name}: ${r.passed ? "✔️" : "❌"}\n`))
+	// await api.revokeToken()
+
+	// if (!results.find((r) => !r.passed)) {
+	// 	console.log("✔️ Looks like the test went well!")
+	// } else {
+	// 	throw new Error("❌ Something in the test went wrong...")
+	// }
 }
 
 test(process.env.ID, process.env.SECRET)

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -343,15 +343,11 @@ const test = async (id: string, secret: string): Promise<void> => {
 
 	const controller = new AbortController()
 	const new_api = api.with({signal: controller.signal})
-
-	setTimeout(() => controller.abort(), 300)
-
-	await Promise.all([
-		attempt(api.getUser, 7276846),
-		attempt(api.getUser, 7276845),
-		attempt(new_api.getUser, 7276846),
-		attempt(new_api.getUser, 7276845),
-	])
+	console.log("reason:", controller.signal.reason)
+	setTimeout(() => controller.abort("manual abort"), 200)
+	await new_api.getUser(7276846)
+	.catch((e: osu.APIError) => console.log(e.original_error))
+	console.log("reason:", controller.signal.reason)
 
 	api.revokeToken()
 

--- a/lib/tests/test.ts
+++ b/lib/tests/test.ts
@@ -341,46 +341,36 @@ const testOther = async (): Promise<boolean> => {
 const test = async (id: string, secret: string): Promise<void> => {
 	api = await osu.API.createAsync({id: Number(id), secret}, undefined, "all") //"http://127.0.0.1:8080")
 
-	const controller = new AbortController()
-	const new_api = api.with({signal: controller.signal})
-	console.log("reason:", controller.signal.reason)
-	setTimeout(() => controller.abort("manual abort"), 200)
-	await new_api.getUser(7276846)
-	.catch((e: osu.APIError) => console.log(e.original_error))
-	console.log("reason:", controller.signal.reason)
+	const tests = [
+		testBeatmapPack,
+		testBeatmap,
+		testBeatmapsetDiscussion,
+		testBeatmapset,
+		testChangelog,
+		testComment,
+		testEvent,
+		testForum,
+		testHome,
+		testMultiplayer,
+		testNews,
+		testRanking,
+		testUser,
+		testWiki,
+		testOther,
+	]
 
-	api.revokeToken()
+	const results: {test_name: string, passed: boolean}[] = []
+	for (let i = 0; i < tests.length; i++) {
+		results.push({test_name: tests[i].name, passed: await tests[i]()})
+	}
+	console.log("\n", ...results.map((r) => `${r.test_name}: ${r.passed ? "✔️" : "❌"}\n`))
+	await api.revokeToken()
 
-	// const tests = [
-	// 	testBeatmapPack,
-	// 	testBeatmap,
-	// 	testBeatmapsetDiscussion,
-	// 	testBeatmapset,
-	// 	testChangelog,
-	// 	testComment,
-	// 	testEvent,
-	// 	testForum,
-	// 	testHome,
-	// 	testMultiplayer,
-	// 	testNews,
-	// 	testRanking,
-	// 	testUser,
-	// 	testWiki,
-	// 	testOther,
-	// ]
-
-	// const results: {test_name: string, passed: boolean}[] = []
-	// for (let i = 0; i < tests.length; i++) {
-	// 	results.push({test_name: tests[i].name, passed: await tests[i]()})
-	// }
-	// console.log("\n", ...results.map((r) => `${r.test_name}: ${r.passed ? "✔️" : "❌"}\n`))
-	// await api.revokeToken()
-
-	// if (!results.find((r) => !r.passed)) {
-	// 	console.log("✔️ Looks like the test went well!")
-	// } else {
-	// 	throw new Error("❌ Something in the test went wrong...")
-	// }
+	if (!results.find((r) => !r.passed)) {
+		console.log("✔️ Looks like the test went well!")
+	} else {
+		throw new Error("❌ Something in the test went wrong...")
+	}
 }
 
 test(process.env.ID, process.env.SECRET)


### PR DESCRIPTION
Closes #33 

The main goal of this PR is to allow users of this package to cancel any ongoing request through the usage of `AbortController`s and ̀`AbortSignal`s
However, it also allows them to have more influence on any request, by changing [its headers and other things](https://www.npmjs.com/package/node-fetch#fetch-options) (with the exception of `body`)

@baileyherbert This PR does things pretty much the way you came up with, so maybe you'd like to check if anything looks odd here?
If you do, there's no need to look through `misc.ts`, its only real addition is the code for merging signals together, which remains completely unchanged