### PR TITLE
Include beatmapset in `beatmaps.getMultiple` response

### DIFF
--- a/lib/namespaces/Beatmap.ts
+++ b/lib/namespaces/Beatmap.ts
@@ -369,7 +369,7 @@ export namespace Beatmap {
 	 * Get extensive beatmap data for up to 50 beatmaps at once!
 	 * @param beatmaps An array of beatmaps or of objects that have the id of the beatmaps you're trying to get
 	 */
-	export async function getMultiple(this: API, beatmaps: Array<Beatmap["id"] | Beatmap>): Promise<Extended.WithFailtimesOwnersMaxcombo[]> {
+	export async function getMultiple(this: API, beatmaps: Array<Beatmap["id"] | Beatmap>): Promise<Extended.WithFailtimesOwnersMaxcomboBeatmapset[]> {
 		const ids = beatmaps.map((beatmap) => typeof beatmap === "number" ? beatmap : beatmap.id)
 		const response = await this.request("get", ["beatmaps"], {ids})
 		return response.beatmaps // It's the only property

--- a/lib/tests/guest/beatmap.test.ts
+++ b/lib/tests/guest/beatmap.test.ts
@@ -22,7 +22,7 @@ const getBeatmaps: Test = async(api) => {
 	const ids = [388463, 4089655]
 	const beatmaps = await api.getBeatmaps(ids)
 	ids.forEach((id, index) => expect(beatmaps[index].id).to.equal(id))
-	expect(validate(beatmaps, "Beatmap.Extended.WithFailtimesOwnersMaxcombo")).to.be.true
+	expect(validate(beatmaps, "Beatmap.Extended.WithFailtimesOwnersMaxcomboBeatmapset")).to.be.true
 	return true
 }
 


### PR DESCRIPTION
The osu! API includes a `BeatmapsetExtended` object in this response. The type of the beatmapset seems to match the individual `getBeatmap` method's response.

<img width="869" height="658" alt="image" src="https://github.com/user-attachments/assets/73e4ecbf-6d61-42d4-86ef-d58d6060de71" />

<img width="869" height="758" alt="image" src="https://github.com/user-attachments/assets/92429e51-4357-446d-9c9d-bdcc561b2f6d" />
